### PR TITLE
Feature/cud 27 fix environment issues

### DIFF
--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -47,6 +47,7 @@ def create_cli(configuration: Configuration):
     ENV_VAR_CONFIG_DIR = f"{APP_NAME_UPPERCASE}_CONFIG_DIR"
     ENV_VAR_GENERATED_CONFIG_DIR = f"{APP_NAME_UPPERCASE}_GENERATED_CONFIG_DIR"
     ENV_VAR_DATA_DIR = f"{APP_NAME_UPPERCASE}_DATA_DIR"
+    ENV_VAR_ENVIRONMENT = f"{APP_NAME_UPPERCASE}_ENVIRONMENT"
 
     APP_VERSION = os.environ.get("APP_VERSION", "latest")
 
@@ -122,7 +123,7 @@ def create_cli(configuration: Configuration):
                 f"{ctx.obj.generated_configuration_dir}",
             ],
             [f"{ENV_VAR_DATA_DIR}", f"{ctx.obj.data_dir}"],
-            ["Environment", f"{environment}"],
+            [f"{ENV_VAR_ENVIRONMENT}", f"{ctx.obj.environment}"],
         ]
 
         # Print out the configuration values as an aligned table
@@ -174,6 +175,7 @@ def create_cli(configuration: Configuration):
                         --volume '{generated_configuration_dir}:{generated_configuration_dir}'
                         --env {ENV_VAR_DATA_DIR}='{data_dir}'
                         --volume '{data_dir}:{data_dir}'
+                        --env {ENV_VAR_ENVIRONMENT}='{environment}'
                         {configuration.docker_image}:{APP_VERSION}
                             --configuration-dir '{configuration_dir}'
                             --data-dir '{data_dir}'

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -114,7 +114,7 @@ def create_cli(configuration: Configuration):
         relaunch_if_required(ctx)
         check_environment()
 
-        # Table of data to print
+        # Table of configuration variables to print
         table = [
             [f"{ENV_VAR_CONFIG_DIR}", f"{ctx.obj.configuration_dir}"],
             [

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import NamedTuple
+from tabulate import tabulate
 
 # vendor libraries
 import click
@@ -113,12 +114,20 @@ def create_cli(configuration: Configuration):
         relaunch_if_required(ctx)
         check_environment()
 
+        # Table of data to print
+        table = [
+            [f"{ENV_VAR_CONFIG_DIR}", f"{ctx.obj.configuration_dir}"],
+            [
+                f"{ENV_VAR_GENERATED_CONFIG_DIR}",
+                f"{ctx.obj.generated_configuration_dir}",
+            ],
+            [f"{ENV_VAR_DATA_DIR}", f"{ctx.obj.data_dir}"],
+            ["Environment", f"{environment}"],
+        ]
+
+        # Print out the configuration values as an aligned table
         logger.info(
-            f"""{APP_NAME_UPPERCASE} v{APP_VERSION} CLI running with:
-    {ENV_VAR_CONFIG_DIR}:           [{ctx.obj.configuration_dir}]
-    {ENV_VAR_GENERATED_CONFIG_DIR}: [{ctx.obj.generated_configuration_dir}]
-    {ENV_VAR_DATA_DIR}:             [{ctx.obj.data_dir}]
-    Environment:          [{environment}]"""
+            f"{APP_NAME_UPPERCASE} v{APP_VERSION} CLI running with:\n{tabulate(table)}"
         )
 
         if ctx.invoked_subcommand is None:

--- a/appcli/main_cli.py
+++ b/appcli/main_cli.py
@@ -70,9 +70,12 @@ class MainCli:
             ]
             command = docker_compose_command + [__get_compose_file_path(ctx)]
             command.extend(subcommand)
-            logger.debug(f'Running [{" ".join(command)}]')
+
+            # Add the 'COMPOSE_PROJECT_NAME' to the environment variables, so that j2 templating can pick up this variable
             my_env = os.environ
             my_env["COMPOSE_PROJECT_NAME"] = PROJECT_NAME
+
+            logger.debug(f'Running [{" ".join(command)}]')
             result = subprocess.run(command, env=my_env)
             sys.exit(result.returncode)
 

--- a/appcli/main_cli.py
+++ b/appcli/main_cli.py
@@ -60,6 +60,8 @@ class MainCli:
             __run_and_exit(ctx, ("logs", "-f") + container)
 
         def __run_and_exit(ctx, subcommand):
+            # The project-name of the docker-compose command is composed of project name and environment
+            # so that multiple environments can run on a single machine without container naming conflicts
             cli_context: CliContext = ctx.obj
             PROJECT_NAME = f"{configuration.app_name}-{cli_context.environment}"
             docker_compose_command = [
@@ -70,13 +72,8 @@ class MainCli:
             ]
             command = docker_compose_command + [__get_compose_file_path(ctx)]
             command.extend(subcommand)
-
-            # Add the 'COMPOSE_PROJECT_NAME' to the environment variables, so that j2 templating can pick up this variable
-            my_env = os.environ
-            my_env["COMPOSE_PROJECT_NAME"] = PROJECT_NAME
-
             logger.debug(f'Running [{" ".join(command)}]')
-            result = subprocess.run(command, env=my_env)
+            result = subprocess.run(command)
             sys.exit(result.returncode)
 
         def __get_compose_file_path(ctx):

--- a/appcli/models.py
+++ b/appcli/models.py
@@ -17,6 +17,9 @@ class CliContext(NamedTuple):
     data_dir: Path
     """ Directory to store data to """
 
+    environment: str
+    """ Environment to run """
+
     subcommand_args: tuple
     """ Arguments passed to CLI subcommand """
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setup(
         "python-dotenv",
         "python-keycloak",
         "ruamel-yaml",
+        "tabulate",
     ],
 )


### PR DESCRIPTION
- Made the 'environment' be passed in as an optional CLI argument rather than an environment variable
- Fixed the tabulated printing by using the `tabulate` library
- Launcher will now re-launch at the specified docker image version