### PR TITLE
Feature/cud 35 pass through env vars

### DIFF
--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -223,16 +223,21 @@ def create_cli(configuration: Configuration):
             error_and_exit(error_msg)
 
     def check_valid_environment_variable_names(variable_names: Iterable[str]):
-        """Check that environment variables passed into appcli are valid environment variable names
+        """Check for invalid environment variable names, and exit with error if any exist.
 
         Args:
             variable_names (Iterable[str]): environment variable names to check
         """
+        errors = []
         for name in variable_names:
             if not re.match("^[a-zA-Z][a-zA-Z0-9_]*$", name):
-                error_and_exit(
-                    f"Invalid environment variable name supplied [{name}]. Names may only contain alphanumeric characters and underscores."
-                )
+                errors.append(name)
+
+        # Non-empty lists evaluate to true
+        if errors:
+            error_and_exit(
+                f"Invalid environment variable name(s) supplied [{errors}]. Names may only contain alphanumeric characters and underscores."
+            )
 
     def relaunch_if_required(ctx: click.Context):
         """Check if the appcli is being run within the context of the appcli container. If not, relaunch with appropriate

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -153,14 +153,13 @@ def create_cli(configuration: Configuration):
             commands=default_commands,
         )
 
-        relaunch_if_required(ctx)
-
         # For the 'launcher' command, no further output/checks required.
         if ctx.invoked_subcommand == "launcher":
             # Don't execute this function any further, continue to run subcommand with the current cli context
             return
 
         check_docker_socket()
+        relaunch_if_required(ctx)
         check_environment()
 
         # Table of configuration variables to print

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -15,8 +15,10 @@ import re
 import shlex
 import subprocess
 import sys
+from math import floor
 from pathlib import Path
 from typing import Iterable
+from time import time
 from tabulate import tabulate
 
 # vendor libraries
@@ -25,6 +27,7 @@ import click
 # local libraries
 from appcli.configure_cli import ConfigureCli
 from appcli.encrypt_cli import EncryptCli
+from appcli.functions import check_valid_environment_variable_names, error_and_exit
 from appcli.init_cli import InitCli
 from appcli.install_cli import InstallCli
 from appcli.launcher_cli import LauncherCli
@@ -108,6 +111,7 @@ def create_cli(configuration: Configuration):
         nargs=2,
         type=click.Tuple([str, Path]),
         multiple=True,
+        callback=check_valid_environment_variable_names,
     )
     @click.option(
         "--additional-env-var",
@@ -116,6 +120,7 @@ def create_cli(configuration: Configuration):
         nargs=2,
         type=click.Tuple([str, str]),
         multiple=True,
+        callback=check_valid_environment_variable_names,
     )
     @click.pass_context
     def cli(
@@ -131,11 +136,6 @@ def create_cli(configuration: Configuration):
             logger.info("Enabling debug logging")
             enable_debug_logging()
 
-        # Fail early on these checks
-        check_valid_environment_variable_names([x[0] for x in additional_data_dir])
-        check_valid_environment_variable_names([x[0] for x in additional_env_var])
-        check_environment()
-
         ctx.obj = CliContext(
             configuration_dir=configuration_dir,
             data_dir=data_dir,
@@ -148,10 +148,12 @@ def create_cli(configuration: Configuration):
             generated_configuration_dir=configuration_dir.joinpath(".generated/conf"),
             app_configuration_file=configuration_dir.joinpath(f"{APP_NAME}.yml"),
             templates_dir=configuration_dir.joinpath("templates"),
-            project_name=f"{APP_NAME}-{environment}",
+            project_name=f"{APP_NAME}_{environment}",
             app_version=APP_VERSION,
             commands=default_commands,
         )
+
+        relaunch_if_required(ctx)
 
         # For the 'launcher' command, no further output/checks required.
         if ctx.invoked_subcommand == "launcher":
@@ -159,7 +161,7 @@ def create_cli(configuration: Configuration):
             return
 
         check_docker_socket()
-        relaunch_if_required(ctx)
+        check_environment()
 
         # Table of configuration variables to print
         table = [
@@ -222,23 +224,6 @@ def create_cli(configuration: Configuration):
 """
             error_and_exit(error_msg)
 
-    def check_valid_environment_variable_names(variable_names: Iterable[str]):
-        """Check for invalid environment variable names, and exit with error if any exist.
-
-        Args:
-            variable_names (Iterable[str]): environment variable names to check
-        """
-        errors = []
-        for name in variable_names:
-            if not re.match("^[a-zA-Z][a-zA-Z0-9_]*$", name):
-                errors.append(name)
-
-        # Non-empty lists evaluate to true
-        if errors:
-            error_and_exit(
-                f"Invalid environment variable name(s) supplied [{errors}]. Names may only contain alphanumeric characters and underscores."
-            )
-
     def relaunch_if_required(ctx: click.Context):
         """Check if the appcli is being run within the context of the appcli container. If not, relaunch with appropriate
         environment variables and mounted volumes.
@@ -257,8 +242,10 @@ def create_cli(configuration: Configuration):
         generated_configuration_dir = cli_context.generated_configuration_dir
         data_dir = cli_context.data_dir
         environment = cli_context.environment
+        seconds_since_epoch = floor(time())
         command = shlex.split(
             f"""docker run
+                        --name osmosis_{cli_context.environment}_relauncher_{seconds_since_epoch}
                         --rm
                         --volume /var/run/docker.sock:/var/run/docker.sock
                         --env APPCLI_MANAGED=Y
@@ -363,15 +350,6 @@ def create_cli(configuration: Configuration):
                 result = False
         if not result:
             error_and_exit(exit_message)
-
-    def error_and_exit(message: str):
-        """Exit with an error message
-
-        Args:
-            message (str): [description]
-        """
-        logger.error(message)
-        sys.exit(1)
 
     for command in default_commands.values():
         cli.add_command(command)

--- a/appcli/configure_cli.py
+++ b/appcli/configure_cli.py
@@ -207,6 +207,8 @@ class ConfigureCli:
                 logger.info("Copying configuration file to [%s] ...", target_file)
                 shutil.copy2(template_file, target_file)
 
+        self.__copy_settings_file_to_generated_dir(cli_context)
+
         logger.info("Saving successful configuration record ...")
         record = {
             "configure": {
@@ -221,6 +223,23 @@ class ConfigureCli:
             json.dumps(record, indent=2, sort_keys=True)
         )
         logger.debug("Configuration record written to [%s]", configuration_record_file)
+
+    def __copy_settings_file_to_generated_dir(self, cli_context: CliContext):
+        """Copies the current settings file to the generated directory as a record of what configuration
+        was used to generate those files.
+
+        Args:
+            cli_context (CliContext): The context of the currently-running cli
+        """
+        logger.debug(
+            "Copying applied settings file to generated configuration directory"
+        )
+        applied_configuration_file = cli_context.generated_configuration_dir.joinpath(
+            cli_context.app_configuration_file.name
+        )
+        shutil.copy2(cli_context.app_configuration_file, applied_configuration_file)
+
+        logger.debug("Applied settings written to [%s]", applied_configuration_file)
 
     def __print_header(self, title):
         logger.info(

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# # -*- coding: utf-8 -*-
+
+"""
+Common functions.
+________________________________________________________________________________
+
+Created by brightSPARK Labs
+www.brightsparklabs.com
+"""
+
+# standard libraries
+import click
+import re
+import sys
+from typing import Iterable, Any
+
+# local libraries
+from appcli.logger import logger
+
+# ------------------------------------------------------------------------------
+# PUBLIC METHODS
+# ------------------------------------------------------------------------------
+
+
+def error_and_exit(message: str):
+    """Exit with an error message
+
+    Args:
+        message (str): [description]
+    """
+    logger.error(message)
+    sys.exit(1)
+
+
+def check_valid_environment_variable_names(
+    ctx: click.Context, param: click.Option, value: click.Tuple
+):
+    """Callback for Click Options to check environment variables are named appropriately for bash
+
+    Args:
+        ctx (click.Context): current cli context
+        param (click.Option): the option parameter to validate
+        value (click.Tuple): the values passed to the option
+    """
+    variable_names: Iterable[str] = [x[0] for x in value]
+    errors = []
+    for name in variable_names:
+        if not re.match("^[a-zA-Z][a-zA-Z0-9_]*$", name):
+            errors.append(name)
+
+    if errors:
+        error_and_exit(
+            f"Invalid environment variable name(s) supplied '{errors}'. Names may only contain alphanumeric characters and underscores."
+        )
+
+    # Return the validated values
+    return value


### PR DESCRIPTION
- Added some pydoc to functions with the google style (used VS plugin https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring)
- Changed the check of environment variables as click Options to be validated by a callback for consistency across all our python files (now that launcher also uses it)
- Changed 'project_name' of launched docker-compose to use underscores
- Early-exit the main cli checks if running the launcher command e.g. doesn't need docker socket to run
- Named the management docker containers that we run
- Copy the applied settings file to the generated config folder on 'configure apply'
- Added ability to add environment variables to launcher script output to feed into management docker container when run