### PR TITLE
Feature/rad 107 remove relaunching and simplify launcher script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint: venv
 	${PYTHON} -m isort -c || echo -e "\nReview isort errors with 'make isort'"
 
 format: venv
-	${PYTHON} -m black . || echo ha
+	${PYTHON} -m black .
 
 isort: venv
 	${PYTHON} -m isort

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -53,13 +53,11 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
     Args:
         configuration (Configuration): the application's configuration settings
     """
-    APP_NAME = configuration.app_name
-    APP_NAME_UPPERCASE = APP_NAME.upper()
-    ENV_VAR_CONFIG_DIR = f"{APP_NAME_UPPERCASE}_CONFIG_DIR"
-    ENV_VAR_GENERATED_CONFIG_DIR = f"{APP_NAME_UPPERCASE}_GENERATED_CONFIG_DIR"
-    ENV_VAR_DATA_DIR = f"{APP_NAME_UPPERCASE}_DATA_DIR"
-    ENV_VAR_ENVIRONMENT = f"{APP_NAME_UPPERCASE}_ENVIRONMENT"
-
+    APP_NAME = configuration.app_name.upper()
+    ENV_VAR_CONFIG_DIR = f"{APP_NAME}_CONFIG_DIR"
+    ENV_VAR_GENERATED_CONFIG_DIR = f"{APP_NAME}_GENERATED_CONFIG_DIR"
+    ENV_VAR_DATA_DIR = f"{APP_NAME}_DATA_DIR"
+    ENV_VAR_ENVIRONMENT = f"{APP_NAME}_ENVIRONMENT"
     APP_VERSION = os.environ.get("APP_VERSION", "latest")
 
     # --------------------------------------------------------------------------
@@ -144,7 +142,9 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             debug=debug,
             key_file=Path(configuration_dir, "key"),
             generated_configuration_dir=configuration_dir.joinpath(".generated"),
-            app_configuration_file=configuration_dir.joinpath(f"{APP_NAME}.yml"),
+            app_configuration_file=configuration_dir.joinpath(
+                f"{APP_NAME.lower()}.yml"
+            ),
             templates_dir=configuration_dir.joinpath("templates"),
             project_name=f"{APP_NAME}_{environment}",
             app_version=APP_VERSION,
@@ -175,7 +175,6 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             )
 
         check_docker_socket()
-        relaunch_if_required(ctx)
         check_environment()
 
         # Table of configuration variables to print
@@ -192,7 +191,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         # Print out the configuration values as an aligned table
         logger.info(
             "%s (version: %s) CLI running with:\n\n%s\n",
-            APP_NAME_UPPERCASE,
+            APP_NAME,
             APP_VERSION,
             tabulate(table, colalign=("right",)),
         )
@@ -224,105 +223,8 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         """Check that the docker socket exists, and exit if it does not
         """
         if not os.path.exists("/var/run/docker.sock"):
-            error_msg = f"""Please relaunch using:
-
-    docker run \\
-        --rm
-        --volume /var/run/docker.sock:/var/run/docker.sock \\
-        {configuration.docker_image}:{APP_VERSION} \\
-            --configuration-dir <dir> \\
-            --data-dir <dir> COMMAND'
-            --environment <str>
-"""
+            error_msg = f"""Docker socket not present. Please launch with a mounted `docker.sock`."""
             error_and_exit(error_msg)
-
-    def relaunch_if_required(ctx: click.Context):
-        """Check if the appcli is being run within the context of the appcli container. If not, relaunch with appropriate
-        environment variables and mounted volumes.
-
-        Args:
-            ctx (click.Context): The current cli context
-        """
-        is_appcli_managed = os.environ.get("APPCLI_MANAGED")
-        if is_appcli_managed is not None:
-            # launched by appcli => no need to relaunch
-            return
-
-        # launched by user, not by appcli => need to launch via appcli
-        cli_context: CliContext = ctx.obj
-        configuration_dir = cli_context.configuration_dir
-        generated_configuration_dir = cli_context.generated_configuration_dir
-        data_dir = cli_context.data_dir
-        environment = cli_context.environment
-        seconds_since_epoch = floor(time())
-        command = shlex.split(
-            f"""docker run
-                        --name osmosis_{cli_context.environment}_relauncher_{seconds_since_epoch}
-                        --rm
-                        --interactive
-                        --tty
-                        --volume /var/run/docker.sock:/var/run/docker.sock
-                        --env APPCLI_MANAGED=Y
-                        --env {ENV_VAR_CONFIG_DIR}='{configuration_dir}'
-                        --volume '{configuration_dir}:{configuration_dir}'
-                        --env {ENV_VAR_GENERATED_CONFIG_DIR}='{generated_configuration_dir}'
-                        --volume '{generated_configuration_dir}:{generated_configuration_dir}'
-                        --env {ENV_VAR_DATA_DIR}='{data_dir}'
-                        --volume '{data_dir}:{data_dir}'
-                        --env {ENV_VAR_ENVIRONMENT}='{environment}'
-            """
-        )
-
-        for name, path in cli_context.additional_data_dirs:
-            command.extend(
-                shlex.split(
-                    f"""
-                        --env {name}="{path}"
-                        --volume "{path}:{path}"
-                    """
-                )
-            )
-
-        for name, value in desired_environment.items():
-            command.extend(shlex.split(f'--env {name}="{value}"'))
-
-        for name, value in cli_context.additional_env_variables:
-            command.extend(shlex.split(f'--env {name}="{value}"'))
-
-        command.extend(
-            shlex.split(
-                f"""
-                    {configuration.docker_image}:{APP_VERSION}
-                    --configuration-dir "{configuration_dir}"
-                    --data-dir "{data_dir}"
-                    --environment "{environment}"
-                """
-            )
-        )
-        for name, path in cli_context.additional_data_dirs:
-            command.extend(shlex.split(f'--additional-data-dir {name}="{path}"'))
-        for name, value in cli_context.additional_env_variables:
-            command.extend(shlex.split(f'--additional-env-var {name}="{value}"'))
-
-        if cli_context.debug:
-            command.append("--debug")
-            # useful when debugging
-            new_env = ""
-            for i, value in enumerate(command):
-                if value == "--env" and i + 1 < len(command):
-                    new_env += f"\t{command[i+1]} \\\n"
-            logger.debug(
-                f"Relaunched environment will be initialised with:\n%s", new_env,
-            )
-        if ctx.invoked_subcommand is not None:
-            command.append(ctx.invoked_subcommand)
-        if cli_context.subcommand_args is not None:
-            command.extend(cli_context.subcommand_args)
-
-        logger.info("Relaunching with initialised environment ...")
-        logger.debug("Running [%s]", " ".join(command))
-        result = subprocess.run(command)
-        sys.exit(result.returncode)
 
     def check_environment():
         """Confirm that mandatory environment variables and additional data directories are defined.

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -11,12 +11,8 @@ www.brightsparklabs.com
 
 # standard libraries
 import os
-import shlex
-import subprocess
 import sys
-from math import floor
 from pathlib import Path
-from time import time
 from typing import Dict, Iterable
 
 # vendor libraries

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -140,13 +140,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             environment=environment,
             subcommand_args=ctx.obj,
             debug=debug,
-            key_file=Path(configuration_dir, "key"),
-            generated_configuration_dir=configuration_dir.joinpath(".generated"),
-            app_configuration_file=configuration_dir.joinpath(
-                f"{APP_NAME.lower()}.yml"
-            ),
-            templates_dir=configuration_dir.joinpath("templates"),
-            project_name=f"{APP_NAME}_{environment}",
+            app_name=APP_NAME,
             app_version=APP_VERSION,
             commands=default_commands,
         )
@@ -154,11 +148,6 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         if ctx.invoked_subcommand is None:
             click.echo(ctx.get_help())
             sys.exit(1)
-
-        # For the 'launcher' command, no further output/checks required.
-        if ctx.invoked_subcommand == "launcher":
-            # Don't execute this function any further, continue to run subcommand with the current cli context
-            return
 
         # attempt to set desired environment
         initialised_environment = {}
@@ -174,6 +163,11 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
                 "Could not set desired environment. Please ensure specified environment variables are set."
             )
 
+        # For the 'launcher' command, no further output/checks required.
+        if ctx.invoked_subcommand == "launcher":
+            # Don't execute this function any further, continue to run subcommand with the current cli context
+            return
+
         check_docker_socket()
         check_environment()
 
@@ -182,7 +176,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             [f"{ENV_VAR_CONFIG_DIR}", f"{ctx.obj.configuration_dir}"],
             [
                 f"{ENV_VAR_GENERATED_CONFIG_DIR}",
-                f"{ctx.obj.generated_configuration_dir}",
+                f"{ctx.obj.get_generated_configuration_dir()}",
             ],
             [f"{ENV_VAR_DATA_DIR}", f"{ctx.obj.data_dir}"],
             [f"{ENV_VAR_ENVIRONMENT}", f"{ctx.obj.environment}"],

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -213,7 +213,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         """Check that the docker socket exists, and exit if it does not
         """
         if not os.path.exists("/var/run/docker.sock"):
-            error_msg = f"""Docker socket not present. Please launch with a mounted `docker.sock`."""
+            error_msg = f"""Docker socket not present. Please launch with a mounted /var/run/docker.sock"""
             error_and_exit(error_msg)
 
     def check_environment():

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -34,12 +34,12 @@ from appcli.functions import (
 from appcli.git_repositories.git_repositories import (
     ConfigurationGitRepository,
     GeneratedConfigurationGitRepository,
-    check_config_dir_dirty,
-    check_config_dir_initialised,
-    check_config_dir_not_initialised,
-    check_generated_config_dir_dirty,
-    check_generated_config_dir_initialised,
-    check_generated_configuration_using_current_configuration,
+    confirm_config_dir_is_not_dirty,
+    confirm_config_dir_initialised,
+    confirm_config_dir_not_initialised,
+    confirm_generated_config_dir_is_not_dirty,
+    confirm_generated_config_dir_initialised,
+    confirm_generated_configuration_is_using_current_configuration,
 )
 from appcli.logger import logger
 from appcli.models.cli_context import CliContext
@@ -185,13 +185,6 @@ class ConfigureCli:
                     "Mandatory environment variable is not defined [%s]", env_variable
                 )
                 result = False
-
-        # if the configuration file exists in the config directory, then don't allow init
-        if os.path.isfile(cli_context.get_app_configuration_file()):
-            logger.error(
-                f"Configuration directory already initialised at [{cli_context.configuration_dir}]"
-            )
-            result = False
 
         return result
 
@@ -388,7 +381,7 @@ class ConfigureCli:
         )
 
         # Cannot run configure init if the config directory already exists.
-        blocking_checks = [check_config_dir_not_initialised]
+        blocking_checks = [confirm_config_dir_not_initialised]
 
         validate(cli_context=cli_context, blocking_checks=blocking_checks, force=False)
 
@@ -408,11 +401,13 @@ class ConfigureCli:
         )
 
         # If the config dir doesn't exist, we cannot apply
-        blocking_checks = [check_config_dir_initialised]
+        blocking_checks = [confirm_config_dir_initialised]
 
-        # If the generated config is dirty, we want blocking but the option to override
+        # If the generated config is dirty, or not running against current config, warn
+        # TODO: Confirm this is the full list of reqs
         forceable_checks = [
-            check_generated_config_dir_dirty,
+            confirm_generated_config_dir_is_not_dirty,
+            confirm_generated_configuration_is_using_current_configuration,
         ]
 
         validate(
@@ -435,12 +430,14 @@ class ConfigureCli:
         """
         logger.info("Checking system configuration is valid before 'configure get' ...")
 
+        # TODO: This is copy pasted. need to validate these checks.
+
         # Block if the config dir doesn't exist as there's nothing to get or set
-        blocking_checks = [check_config_dir_initialised]
+        blocking_checks = [confirm_config_dir_initialised]
 
         # If the generated config is dirty, we want blocking but the option to override
         forceable_checks = [
-            check_generated_config_dir_dirty,
+            confirm_generated_config_dir_is_not_dirty,
         ]
 
         validate(

--- a/appcli/commands/encrypt_cli.py
+++ b/appcli/commands/encrypt_cli.py
@@ -45,7 +45,7 @@ class EncryptCli:
         def encrypt(ctx, text: str):
 
             cli_context: CliContext = ctx.obj
-            key_file: Path = cli_context.key_file
+            key_file: Path = cli_context.get_key_file()
             if not key_file.is_file():
                 logger.info("Creating encryption key at [%s]", key_file)
                 crypto.create_and_save_key(key_file)

--- a/appcli/commands/install_cli.py
+++ b/appcli/commands/install_cli.py
@@ -23,6 +23,7 @@ import click
 from jinja2 import Template
 
 # local libraries
+from appcli.functions import error_and_exit
 from appcli.logger import logger
 from appcli.models.configuration import Configuration
 
@@ -101,8 +102,7 @@ class InstallCli:
             prerequisites_met = False
 
         if not prerequisites_met:
-            logger.error("Prerequisite checks failed")
-            sys.exit(1)
+            error_and_exit("Prerequisite checks failed")
 
     def __setup_application_home(self, overwrite_install_dir):
         logger.info(f"Setting up [{self.app_home}] ...")

--- a/appcli/commands/launcher_cli.py
+++ b/appcli/commands/launcher_cli.py
@@ -60,16 +60,12 @@ class LauncherCli:
             )
             logger.debug(f"Read template file [{LAUNCHER_TEMPLATE_FILENAME}]")
 
-            # TODO: Pass through from CLI builder
-            desired_environment = {}
-
             render_variables = {
                 "app_version": os.environ.get("APP_VERSION", "latest"),
                 "app_name": configuration.app_name.upper(),
                 "cli_context": ctx.obj,
                 "configuration": self.configuration,
-                "current_datetime": datetime.datetime.now(),
-                "desired_environment": desired_environment,
+                "current_datetime": f"{datetime.datetime.utcnow().isoformat()}+00:00",  # Since we're using utcnow(), we specify the offset manually
             }
 
             logger.debug(

--- a/appcli/commands/launcher_cli.py
+++ b/appcli/commands/launcher_cli.py
@@ -21,9 +21,7 @@ import click
 from jinja2 import StrictUndefined, Template
 
 # local libraries
-from appcli.functions import extract_valid_environment_variable_names
 from appcli.logger import logger
-from appcli.models.cli_context import CliContext
 from appcli.models.configuration import Configuration
 from appcli import templates
 

--- a/appcli/commands/launcher_cli.py
+++ b/appcli/commands/launcher_cli.py
@@ -21,6 +21,7 @@ import click
 from jinja2 import StrictUndefined, Template
 
 # local libraries
+from appcli.functions import error_and_exit
 from appcli.logger import logger
 from appcli.models.configuration import Configuration
 from appcli import templates
@@ -80,11 +81,9 @@ class LauncherCli:
                 output_text = template.render(render_variables)
                 print(output_text)
             except Exception as e:
-                logger.error(
-                    "Could not generate file from template. The configuration file is likely missing a setting: %s",
-                    e,
+                error_and_exit(
+                    f"Could not generate file from template. The configuration file is likely missing a setting: {e}"
                 )
-                exit(1)
 
         # expose the cli command
         self.commands = {"launcher": launcher}

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -16,7 +16,7 @@ import sys
 import click
 
 # local libraries
-from appcli.functions import validate
+from appcli.functions import execute_validation_functions
 from appcli.git_repositories.git_repositories import (
     confirm_config_dir_is_not_dirty,
     confirm_generated_config_dir_is_not_dirty,
@@ -48,7 +48,7 @@ class MainCli:
 
         @click.command(help="Starts the system.")
         @click.option(
-            "--force", is_flag=True, help="Force start through validation checks",
+            "--force", is_flag=True, help="Force start even if validation checks fail",
         )
         @click.pass_context
         def start(ctx, force):
@@ -71,7 +71,7 @@ class MainCli:
 
         @click.command(help="Stops the system.")
         @click.option(
-            "--force", is_flag=True, help="Force stop through validation checks",
+            "--force", is_flag=True, help="Force stop even if validation checks fail",
         )
         @click.pass_context
         def stop(ctx, force):
@@ -117,25 +117,25 @@ class MainCli:
 
         Args:
             cli_context (CliContext): the current cli context
-            force (bool, optional): If True, only warns on validation checks. Defaults to False.
+            force (bool, optional): If True, only warns on validation failures, rather than exiting
         """
         logger.info("Checking system configuration is valid before starting ...")
 
         # Only need to block if the generated configuration is not present
-        must_have_checks = [confirm_generated_config_dir_exists]
+        must_succeed_checks = [confirm_generated_config_dir_exists]
 
         # If either config dirs are dirty, or generated config doesn't align with
         # current config, then warn before allowing start.
-        should_have_checks = [
+        should_succeed_checks = [
             confirm_config_dir_is_not_dirty,
             confirm_generated_config_dir_is_not_dirty,
             confirm_generated_configuration_is_using_current_configuration,
         ]
 
-        validate(
+        execute_validation_functions(
             cli_context=cli_context,
-            must_have_checks=must_have_checks,
-            should_have_checks=should_have_checks,
+            must_succeed_checks=must_succeed_checks,
+            should_succeed_checks=should_succeed_checks,
             force=force,
         )
 
@@ -146,13 +146,13 @@ class MainCli:
 
         Args:
             cli_context (CliContext): the current cli context
-            force (bool, optional): If True, only warns on validation checks. Defaults to False.
+            force (bool, optional): If True, only warns on validation failures, rather than exiting
         """
         logger.info("Checking system configuration is valid before stopping ...")
 
-        validate(
+        execute_validation_functions(
             cli_context=cli_context,
-            must_have_checks=[
+            must_succeed_checks=[
                 confirm_generated_config_dir_exists
             ],  # Only block stopping the system on the generated config not existing
             force=force,

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -92,7 +92,6 @@ class MainCli:
             logger.info("Stop command finished with code [%i]", result.returncode)
             sys.exit(result.returncode)
 
-        # TODO: Do validation checks before running 'logs'. Block if generated config doesn't exist.
         # expose the cli commands
         self.commands = {
             "start": start,

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -22,11 +22,11 @@ from appcli.functions import error_and_exit, validate
 from appcli.git_repositories.git_repositories import (
     ConfigurationGitRepository,
     GeneratedConfigurationGitRepository,
-    check_config_dir_dirty,
-    check_config_dir_initialised,
-    check_generated_config_dir_dirty,
-    check_generated_config_dir_initialised,
-    check_generated_configuration_using_current_configuration,
+    confirm_config_dir_is_not_dirty,
+    confirm_config_dir_initialised,
+    confirm_generated_config_dir_is_not_dirty,
+    confirm_generated_config_dir_initialised,
+    confirm_generated_configuration_is_using_current_configuration,
 )
 from appcli.logger import logger
 from appcli.models.cli_context import CliContext
@@ -128,14 +128,12 @@ class MainCli:
         logger.info("Checking system configuration is valid before starting ...")
 
         # Only need to block if the generated configuration is not generated
-        blocking_checks = [check_generated_config_dir_initialised]
+        blocking_checks = [confirm_generated_config_dir_initialised]
 
-        # These checks are more 'nice-to-have' and are therefore '--force'-able
         forceable_checks = [
-            check_config_dir_dirty,
-            check_config_dir_initialised,
-            check_generated_config_dir_dirty,
-            check_generated_configuration_using_current_configuration,
+            confirm_config_dir_is_not_dirty,  # if the config dir is dirty, want the user to run configure apply, warn
+            confirm_generated_config_dir_is_not_dirty,  # if the generated config is dirty, warn
+            confirm_generated_configuration_is_using_current_configuration,  # if the generated config isn't aligned with config, warn
         ]
 
         validate(
@@ -158,7 +156,9 @@ class MainCli:
 
         validate(
             cli_context=cli_context,
-            blocking_checks=[check_generated_config_dir_initialised],
+            blocking_checks=[
+                confirm_generated_config_dir_initialised
+            ],  # Only block on the generated config not existing
             force=force,
         )
 

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -18,10 +18,15 @@ import sys
 import click
 
 # local libraries
-from appcli.functions import error_and_exit, get_generated_configuration_metadata_file
+from appcli.functions import error_and_exit, validate
 from appcli.git_repositories.git_repositories import (
     ConfigurationGitRepository,
     GeneratedConfigurationGitRepository,
+    check_config_dir_dirty,
+    check_config_dir_initialised,
+    check_generated_config_dir_dirty,
+    check_generated_config_dir_initialised,
+    check_generated_configuration_using_current_configuration,
 )
 from appcli.logger import logger
 from appcli.models.cli_context import CliContext
@@ -48,9 +53,7 @@ class MainCli:
 
         @click.command(help="Starts the system.")
         @click.option(
-            "--force",
-            is_flag=True,
-            help="Force start even if generated configuration is out of date",
+            "--force", is_flag=True, help="Force start through validation checks",
         )
         @click.pass_context
         def start(ctx, force):
@@ -60,7 +63,7 @@ class MainCli:
             hooks.pre_start(ctx)
 
             cli_context: CliContext = ctx.obj
-            self.__pre_start_configuration_repository_checks(cli_context, force=force)
+            self.__pre_start_validation(cli_context, force=force)
 
             logger.info("Starting %s ...", configuration.app_name)
             result = self.orchestrator.start(ctx.obj)
@@ -72,12 +75,18 @@ class MainCli:
             sys.exit(result.returncode)
 
         @click.command(help="Stops the system.")
+        @click.option(
+            "--force", is_flag=True, help="Force stop through validation checks",
+        )
         @click.pass_context
-        def stop(ctx):
+        def stop(ctx, force):
             hooks = self.cli_configuration.hooks
 
             logger.debug("Running pre-stop hook")
             hooks.pre_stop(ctx)
+
+            cli_context: CliContext = ctx.obj
+            self.__pre_stop_validation(cli_context, force=force)
 
             logger.info("Stopping %s ...", configuration.app_name)
             result = self.orchestrator.stop(ctx.obj)
@@ -88,6 +97,7 @@ class MainCli:
             logger.info("Stop command finished with code [%i]", result.returncode)
             sys.exit(result.returncode)
 
+        # TODO: Do validation checks before running 'logs'. Block if generated config doesn't exist.
         # expose the cli commands
         self.commands = {
             "start": start,
@@ -108,84 +118,48 @@ class MainCli:
                 orchestrator.add_command(command)
             self.commands.update({"orchestrator": orchestrator})
 
-    def __pre_start_configuration_repository_checks(
-        self, cli_context: CliContext, force: bool = False
-    ):
+    def __pre_start_validation(self, cli_context: CliContext, force: bool = False):
         """Ensures the system is in a valid state for startup.
 
         Args:
             cli_context (CliContext): the current cli context
-            force (bool, optional): If False, will only warn on error. On True will error and exit on error. Defaults to False.
+            force (bool, optional): If True, only warns on validation checks. Defaults to False.
         """
-        logger.info("Checking system configuration is valid ...")
+        logger.info("Checking system configuration is valid before starting ...")
 
-        config_repo = ConfigurationGitRepository(cli_context)
-        generated_config_repo = GeneratedConfigurationGitRepository(cli_context)
+        # Only need to block if the generated configuration is not generated
+        blocking_checks = [check_generated_config_dir_initialised]
 
-        errors = []
-        if not config_repo.repo_exists():
-            errors.append(
-                f"Configuration repository does not exist at [{config_repo.repo_path}]. Please run `configure init`."
-            )
-        if not generated_config_repo.repo_exists():
-            errors.append(
-                f"Generated configuration repository does not exist at [{generated_config_repo.repo_path}]. Please run `configure apply`."
-            )
-        if errors:
-            error_and_exit("Configuration invalid:\n- " + "\n- ".join(errors))
-        logger.info("Configuration directories exist")
+        # These checks are more 'nice-to-have' and are therefore '--force'-able
+        forceable_checks = [
+            check_config_dir_dirty,
+            check_config_dir_initialised,
+            check_generated_config_dir_dirty,
+            check_generated_configuration_using_current_configuration,
+        ]
 
-        # Check if the configuration directory contains unapplied changes
-        logger.debug("Checking for dirty configuration repository ...")
-        if config_repo.is_dirty(untracked_files=True):
-            errors.append(
-                "Configuration contains changes which have not been applied. Please run `configure apply`."
-            )
+        validate(
+            cli_context=cli_context,
+            blocking_checks=blocking_checks,
+            forceable_checks=forceable_checks,
+            force=force,
+        )
 
-        # Check if the generated configuration repository has manual modifications to tracked files
-        logger.debug("Checking for dirty generated configuration repository ...")
-        if generated_config_repo.is_dirty(untracked_files=False):
-            errors.append(
-                f"Generated configuration at [{generated_config_repo.repo_path}] has been manually modified."
-            )
+        logger.info("System configuration is valid")
 
-        # Check if the generated configuration is against current configuration commit
-        logger.debug("Checking generated configuration is up to date ...")
-        metadata_file = get_generated_configuration_metadata_file(cli_context)
-        if not os.path.isfile(metadata_file):
-            errors.append(
-                f"Could not find a metadata file at [{metadata_file}]. Please run `configure apply`"
-            )
-        else:
-            with open(metadata_file, "r") as f:
-                metadata = json.load(f)
-                logger.debug("Metadata from generated configuration: %s", metadata)
+    def __pre_stop_validation(self, cli_context: CliContext, force: bool = False):
+        """Ensures the system is in a valid state for stop.
 
-            generated_commit_hash = metadata["generated_from_commit"]
-            configuration_commit_hash = config_repo.get_current_commit_hash()
-            if generated_commit_hash != configuration_commit_hash:
-                logger.debug(
-                    "Generated configuration hash [%s] does not match configuration hash [%s]",
-                    generated_commit_hash,
-                    configuration_commit_hash,
-                )
-                errors.append(
-                    "Generated configuration is out of date. Please run `configure apply`."
-                )
+        Args:
+            cli_context (CliContext): the current cli context
+            force (bool, optional): If True, only warns on validation checks. Defaults to False.
+        """
+        logger.info("Checking system configuration is valid before stopping ...")
 
-        if errors:
-            error_messages = "\n- ".join(errors)
-            if not force:
-                error_and_exit(
-                    f"""System configuration is invalid:
-- {error_messages}
-
-Use the `--force` flag to ignore these issues.
-Otherwise please address the issues and run `start` again."""
-                )
-            logger.warn(
-                "Force flag `--force` applied. Ignoring the following issues:\n- %s",
-                error_messages,
-            )
+        validate(
+            cli_context=cli_context,
+            blocking_checks=[check_generated_config_dir_initialised],
+            force=force,
+        )
 
         logger.info("System configuration is valid")

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -10,22 +10,17 @@ www.brightsparklabs.com
 """
 
 # standard libraries
-import json
-import os
 import sys
 
 # vendor libraries
 import click
 
 # local libraries
-from appcli.functions import error_and_exit, validate
+from appcli.functions import validate
 from appcli.git_repositories.git_repositories import (
-    ConfigurationGitRepository,
-    GeneratedConfigurationGitRepository,
     confirm_config_dir_is_not_dirty,
-    confirm_config_dir_initialised,
     confirm_generated_config_dir_is_not_dirty,
-    confirm_generated_config_dir_initialised,
+    confirm_generated_config_dir_exists,
     confirm_generated_configuration_is_using_current_configuration,
 )
 from appcli.logger import logger
@@ -127,19 +122,21 @@ class MainCli:
         """
         logger.info("Checking system configuration is valid before starting ...")
 
-        # Only need to block if the generated configuration is not generated
-        blocking_checks = [confirm_generated_config_dir_initialised]
+        # Only need to block if the generated configuration is not present
+        must_have_checks = [confirm_generated_config_dir_exists]
 
-        forceable_checks = [
-            confirm_config_dir_is_not_dirty,  # if the config dir is dirty, want the user to run configure apply, warn
-            confirm_generated_config_dir_is_not_dirty,  # if the generated config is dirty, warn
-            confirm_generated_configuration_is_using_current_configuration,  # if the generated config isn't aligned with config, warn
+        # If either config dirs are dirty, or generated config doesn't align with
+        # current config, then warn before allowing start.
+        should_have_checks = [
+            confirm_config_dir_is_not_dirty,
+            confirm_generated_config_dir_is_not_dirty,
+            confirm_generated_configuration_is_using_current_configuration,
         ]
 
         validate(
             cli_context=cli_context,
-            blocking_checks=blocking_checks,
-            forceable_checks=forceable_checks,
+            must_have_checks=must_have_checks,
+            should_have_checks=should_have_checks,
             force=force,
         )
 
@@ -156,9 +153,9 @@ class MainCli:
 
         validate(
             cli_context=cli_context,
-            blocking_checks=[
-                confirm_generated_config_dir_initialised
-            ],  # Only block on the generated config not existing
+            must_have_checks=[
+                confirm_generated_config_dir_exists
+            ],  # Only block stopping the system on the generated config not existing
             force=force,
         )
 

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -94,51 +94,65 @@ def extract_valid_environment_variable_names(
     return tuple((k, deduplicated[k]) for k in sorted(deduplicated.keys()))
 
 
-def validate(
+def execute_validation_functions(
     cli_context: CliContext,
-    must_have_checks: Iterable[Callable[[click.Context], None]] = [],
-    should_have_checks: Iterable[Callable[[click.Context], None]] = [],
+    must_succeed_checks: Iterable[Callable[[click.Context], None]] = [],
+    should_succeed_checks: Iterable[Callable[[click.Context], None]] = [],
     force: bool = False,
 ):
-    """Perform validation checks, and exit if failed (and not overridden)
+    """Run validation check functions. There are two types of checks: 'must' checks and 'should' checks.
+
+    'Must' check functions must complete and exit without raising Exceptions, or else the whole validation check will fail.
+
+    'Should' check functions should completed and exit without raising Exceptions. If any Exceptions are raised, and 'force' is False,
+    then this validation check will fail. If Exceptions are raised and 'force' is True, then these are raised as warning to the user
+    but the validation is successful.
+
+    All the 'Must' and 'Should' checks (taking into account 'force') need to succeed in order for this validation to be successful.
 
     Args:
         cli_context (CliContext): the current cli context
-        must_have_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are not '--force'able. Defaults to [].
-        should_have_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are '--force'able. Defaults to [].
-        force (bool, optional): Whether to force pass any should_have_checks that fail. Defaults to False.
+        must_succeed_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run which must not raise any exceptions
+            in order for the validation to succeed.
+        should_succeed_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run, which may raise exceptions. If
+            'force' is True, any Exceptions are displayed as 'warnings' and won't fail the validation check. If 'force' is False, any Exceptions
+            will failed the validation.
+        force (bool, optional): Whether to ignore any should_succeed_checks which fail. Defaults to False.
     """
     logger.info("Performing validation ...")
 
     # Get the blocking errors
-    blocking_errors = _run_checks(cli_context, must_have_checks)
-    blocking_error_messages = "\n- ".join(blocking_errors)
+    must_succeed_errors = _run_checks(cli_context, must_succeed_checks)
+    must_succeed_error_messages = "\n- ".join(must_succeed_errors)
 
     # Get the non-blocking errors - 'warnings'
-    forceable_errors = _run_checks(cli_context, should_have_checks)
-    forceable_error_messages = "\n- ".join(forceable_errors)
+    should_succeed_errors = _run_checks(cli_context, should_succeed_checks)
+    should_succeed_error_messages = "\n- ".join(should_succeed_errors)
 
-    all_errors = blocking_errors + forceable_errors
+    all_errors = must_succeed_errors + should_succeed_errors
 
     # If there's no errors, validation ends here and is successful
     if not all_errors:
         logger.debug("No errors found in validation.")
         return
 
-    # If there's no blocking errors, and there's forceable errors and the force flag is provided, warn the user
-    # but succeed in validation.
-    if not blocking_errors and forceable_errors and force:
+    # If there's errors in the 'should' checks and force is True, then only warn for those errors
+    if should_succeed_errors and force:
         logger.warn(
             "Force flag `--force` applied. Ignoring the following issues:\n- %s",
-            forceable_error_messages,
+            should_succeed_error_messages,
         )
-        return
+        # If there's no 'must' errors now, validation is successful
+        if not must_succeed_errors:
+            return
 
     output_error_message = "Errors found during validation.\n\n"
-    if forceable_errors:
-        output_error_message += f"Force-able issues:\n- {forceable_error_messages}\nUse the `--force` flag to ignore these issues.\n\n"
-    if blocking_errors:
-        output_error_message += f"Blocking issues (these cannot be bypassed and must be fixed):\n- {blocking_error_messages}\n\n"
+
+    # If there's forced 'should' errors, then we've already warned, and don't need to include this in the error message
+    if should_succeed_errors and not force:
+        output_error_message += f"Force-able issues:\n- {should_succeed_error_messages}\nUse the `--force` flag to ignore these issues.\n\n"
+    if must_succeed_errors:
+        output_error_message += f"Blocking issues (these cannot be bypassed and must be fixed):\n- {must_succeed_error_messages}\n\n"
     output_error_message += "Validation failed. See error messages above."
     error_and_exit(output_error_message)
 
@@ -146,7 +160,7 @@ def validate(
 def _run_checks(
     cli_context: CliContext, checks: Iterable[Callable[[click.Context], None]]
 ) -> List[str]:
-    """Runs a set of functions which either return None or throws an error. Returns all the error messages.
+    """Runs a set of functions which either return None or raises an Exception. Returns all Exception error messages.
 
     Args:
         cli_context (CliContext): the current context of the cli

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -9,12 +9,12 @@ Created by brightSPARK Labs
 www.brightsparklabs.com
 """
 
-import re
-import sys
-from pathlib import Path
-
 # standard libraries
 import click
+from pathlib import Path
+import re
+import sys
+from typing import Callable, Iterable
 
 # local libraries
 from appcli.logger import logger
@@ -51,7 +51,7 @@ def error_and_exit(message: str):
 
 
 def get_generated_configuration_metadata_file(cli_context: CliContext) -> Path:
-    generated_configuration_dir = cli_context.generated_configuration_dir
+    generated_configuration_dir = cli_context.get_generated_configuration_dir()
     return generated_configuration_dir.joinpath(METADATA_FILE_NAME)
 
 
@@ -83,3 +83,63 @@ def extract_valid_environment_variable_names(
     # Remove duplicates (last one takes precedence) and return
     deduplicated = {k: v for k, v in output}
     return tuple((k, deduplicated[k]) for k in sorted(deduplicated.keys()))
+
+
+def validate(
+    cli_context: CliContext,
+    blocking_checks: Iterable[Callable[[click.Context], None]] = [],
+    forceable_checks: Iterable[Callable[[click.Context], None]] = [],
+    force: bool = False,
+):
+    """Perform validation checks, and exit if failed (and not overridden)
+    
+    Args:
+        cli_context (CliContext): the current cli context
+        blocking_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are not '--force'able. Defaults to [].
+        forceable_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are '--force'able. Defaults to [].
+        force (bool, optional): Whether to force pass any forceable_checks that fail. Defaults to False.
+    """
+    logger.info("Performing validation ...")
+
+    blocking_errors = _run_checks(cli_context, blocking_checks)
+    blocking_error_messages = "\n- ".join(blocking_errors)
+
+    forceable_errors = _run_checks(cli_context, forceable_checks)
+    forceable_error_messages = "\n- ".join(forceable_errors)
+
+    all_errors = blocking_errors + forceable_errors
+
+    if not all_errors:
+        logger.debug("No errors found in validation.")
+        return
+
+    if not blocking_errors and forceable_errors and force:
+        logger.warn(
+            "Force flag `--force` applied. Ignoring the following issues:\n- %s",
+            forceable_error_messages,
+        )
+        return
+
+    output_error_message = "Errors found during validation.\n\n"
+    if forceable_errors:
+        output_error_message += f"Force-able issues:\n- {forceable_error_messages}\nUse the `--force` flag to ignore these issues.\n\n"
+    if blocking_errors:
+        output_error_message += f"Blocking issues (these cannot be bypassed and must be fixed):\n- {blocking_error_messages}\n\n"
+    output_error_message += "Validation failed. See error messages above."
+    error_and_exit(output_error_message)
+
+
+def _run_checks(
+    cli_context: CliContext, checks: Iterable[Callable[[click.Context], None]]
+):
+    errors = []
+    for check in checks:
+        check_name = check.__name__
+        try:
+            logger.debug(f"Running check: [{check_name}]")
+            check(cli_context)
+            logger.debug(f"PASSED [{check_name}]")
+        except Exception as e:
+            errors.append(str(e))
+            logger.debug(f"FAILED [{check_name}]")
+    return errors

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -87,24 +87,24 @@ def extract_valid_environment_variable_names(
 
 def validate(
     cli_context: CliContext,
-    blocking_checks: Iterable[Callable[[click.Context], None]] = [],
-    forceable_checks: Iterable[Callable[[click.Context], None]] = [],
+    must_have_checks: Iterable[Callable[[click.Context], None]] = [],
+    should_have_checks: Iterable[Callable[[click.Context], None]] = [],
     force: bool = False,
 ):
     """Perform validation checks, and exit if failed (and not overridden)
-    
+
     Args:
         cli_context (CliContext): the current cli context
-        blocking_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are not '--force'able. Defaults to [].
-        forceable_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are '--force'able. Defaults to [].
-        force (bool, optional): Whether to force pass any forceable_checks that fail. Defaults to False.
+        must_have_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are not '--force'able. Defaults to [].
+        should_have_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run that are '--force'able. Defaults to [].
+        force (bool, optional): Whether to force pass any should_have_checks that fail. Defaults to False.
     """
     logger.info("Performing validation ...")
 
-    blocking_errors = _run_checks(cli_context, blocking_checks)
+    blocking_errors = _run_checks(cli_context, must_have_checks)
     blocking_error_messages = "\n- ".join(blocking_errors)
 
-    forceable_errors = _run_checks(cli_context, forceable_checks)
+    forceable_errors = _run_checks(cli_context, should_have_checks)
     forceable_error_messages = "\n- ".join(forceable_errors)
 
     all_errors = blocking_errors + forceable_errors

--- a/appcli/git_repositories/git_repositories.py
+++ b/appcli/git_repositories/git_repositories.py
@@ -150,6 +150,15 @@ class GeneratedConfigurationGitRepository(GitRepository):
 
 
 def confirm_config_dir_exists(cli_context: CliContext):
+    """Confirm that the configuration repository exists.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if the configuration repository does *not* exist.
+    """
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if not config_repo.repo_exists():
         raise Exception(
@@ -158,12 +167,30 @@ def confirm_config_dir_exists(cli_context: CliContext):
 
 
 def confirm_config_dir_not_exists(cli_context: CliContext):
+    """Confirm that the configuration repository does *not* exist.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if the configuration repository exists.
+    """
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if config_repo.repo_exists():
         raise Exception(f"Configuration already exists at [{config_repo.repo_path}].")
 
 
 def confirm_generated_config_dir_exists(cli_context: CliContext):
+    """Confirm that the generated configuration repository exists.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if the generated configuration repository does not exist.
+    """
     generated_config_repo: GeneratedConfigurationGitRepository = GeneratedConfigurationGitRepository(
         cli_context
     )
@@ -174,6 +201,15 @@ def confirm_generated_config_dir_exists(cli_context: CliContext):
 
 
 def confirm_config_dir_is_not_dirty(cli_context: CliContext):
+    """Confirm that the configuration repository has not been modified and not 'applied'.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if the configuration repository has been modified and not 'applied'.
+    """
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if config_repo.is_dirty(untracked_files=True):
         raise Exception(
@@ -182,6 +218,15 @@ def confirm_config_dir_is_not_dirty(cli_context: CliContext):
 
 
 def confirm_generated_config_dir_is_not_dirty(cli_context: CliContext):
+    """Confirm that the generated configuration repository has not been manually modified and not checked-in.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if the generated configuration repository has been manually modified and not checked in.
+    """
     generated_config_repo: GeneratedConfigurationGitRepository = GeneratedConfigurationGitRepository(
         cli_context
     )
@@ -194,6 +239,15 @@ def confirm_generated_config_dir_is_not_dirty(cli_context: CliContext):
 def confirm_generated_configuration_is_using_current_configuration(
     cli_context: CliContext,
 ):
+    """Confirm that the generated configuration directory was generated from the current state configuration directory.
+    If this fails, it will raise a general Exception with the error message.
+
+    Args:
+        cli_context (CliContext): the current cli context
+
+    Raises:
+        Exception: Raised if metadata file not found, or generated config is out of sync with config.
+    """
     metadata_file = get_generated_configuration_metadata_file(cli_context)
     if not os.path.isfile(metadata_file):
         raise Exception(
@@ -215,5 +269,5 @@ def confirm_generated_configuration_is_using_current_configuration(
             configuration_commit_hash,
         )
         raise Exception(
-            "Generated configuration is out of date. Please run `configure apply`."
+            "Generated configuration is out of sync with raw configuration. Please run `configure apply`."
         )

--- a/appcli/git_repositories/git_repositories.py
+++ b/appcli/git_repositories/git_repositories.py
@@ -149,7 +149,7 @@ class GeneratedConfigurationGitRepository(GitRepository):
 # ------------------------------------------------------------------------------
 
 
-def check_config_dir_initialised(cli_context: CliContext):
+def confirm_config_dir_initialised(cli_context: CliContext):
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if not config_repo.repo_exists():
         raise Exception(
@@ -157,13 +157,13 @@ def check_config_dir_initialised(cli_context: CliContext):
         )
 
 
-def check_config_dir_not_initialised(cli_context: CliContext):
+def confirm_config_dir_not_initialised(cli_context: CliContext):
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if config_repo.repo_exists():
         raise Exception(f"Configuration already exists at [{config_repo.repo_path}].")
 
 
-def check_generated_config_dir_initialised(cli_context: CliContext):
+def confirm_generated_config_dir_initialised(cli_context: CliContext):
     generated_config_repo: GeneratedConfigurationGitRepository = GeneratedConfigurationGitRepository(
         cli_context
     )
@@ -173,7 +173,7 @@ def check_generated_config_dir_initialised(cli_context: CliContext):
         )
 
 
-def check_config_dir_dirty(cli_context: CliContext):
+def confirm_config_dir_is_not_dirty(cli_context: CliContext):
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if config_repo.is_dirty(untracked_files=True):
         raise Exception(
@@ -181,7 +181,7 @@ def check_config_dir_dirty(cli_context: CliContext):
         )
 
 
-def check_generated_config_dir_dirty(cli_context: CliContext):
+def confirm_generated_config_dir_is_not_dirty(cli_context: CliContext):
     generated_config_repo: GeneratedConfigurationGitRepository = GeneratedConfigurationGitRepository(
         cli_context
     )
@@ -191,7 +191,9 @@ def check_generated_config_dir_dirty(cli_context: CliContext):
         )
 
 
-def check_generated_configuration_using_current_configuration(cli_context: CliContext):
+def confirm_generated_configuration_is_using_current_configuration(
+    cli_context: CliContext,
+):
     metadata_file = get_generated_configuration_metadata_file(cli_context)
     if not os.path.isfile(metadata_file):
         raise Exception(

--- a/appcli/git_repositories/git_repositories.py
+++ b/appcli/git_repositories/git_repositories.py
@@ -149,7 +149,7 @@ class GeneratedConfigurationGitRepository(GitRepository):
 # ------------------------------------------------------------------------------
 
 
-def confirm_config_dir_initialised(cli_context: CliContext):
+def confirm_config_dir_exists(cli_context: CliContext):
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if not config_repo.repo_exists():
         raise Exception(
@@ -157,13 +157,13 @@ def confirm_config_dir_initialised(cli_context: CliContext):
         )
 
 
-def confirm_config_dir_not_initialised(cli_context: CliContext):
+def confirm_config_dir_not_exists(cli_context: CliContext):
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)
     if config_repo.repo_exists():
         raise Exception(f"Configuration already exists at [{config_repo.repo_path}].")
 
 
-def confirm_generated_config_dir_initialised(cli_context: CliContext):
+def confirm_generated_config_dir_exists(cli_context: CliContext):
     generated_config_repo: GeneratedConfigurationGitRepository = GeneratedConfigurationGitRepository(
         cli_context
     )

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -38,30 +38,27 @@ class CliContext(NamedTuple):
     # derived data
     # ---------------------------------
 
-    key_file: Path
-    """ File containing key for encryption/decryption. """
+    def get_key_file(self) -> Path:
+        return Path(self.configuration_dir, "key")
 
-    generated_configuration_dir: Path
-    """ Directory to store the generated configuration files to. """
+    def get_generated_configuration_dir(self) -> Path:
+        return self.configuration_dir.joinpath(".generated")
 
-    app_configuration_file: Path
-    """
-    Path to a YAML file containing variables which are applied to the
-    templates to generate the final configuration files.
-    """
+    def get_app_configuration_file(self) -> Path:
+        return self.configuration_dir.joinpath(f"{self.app_name.lower()}.yml")
 
-    templates_dir: Path
-    """
-    Directory containing jinja2 templates used to generate the final
-    configuration files.
-    """
+    def get_templates_dir(self) -> Path:
+        return self.configuration_dir.joinpath("templates")
 
-    project_name: str
-    """ Project name for launching docker containers/networks. """
+    def get_project_name(self) -> str:
+        return f"{self.app_name}_{self.environment}"
 
     # ---------------------------------
     # cli build data
     # ---------------------------------
+
+    app_name: str
+    """ The application's name """
 
     app_version: str
     """ The application's version """

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -35,6 +35,19 @@ class CliContext(NamedTuple):
     """ Whether to print debug logs. """
 
     # ---------------------------------
+    # cli build data
+    # ---------------------------------
+
+    app_name: str
+    """ The application's name """
+
+    app_version: str
+    """ The application's version """
+
+    commands: Dict
+    """ Internal commands. """
+
+    # ---------------------------------
     # derived data
     # ---------------------------------
 
@@ -77,16 +90,3 @@ class CliContext(NamedTuple):
             str: the project name
         """
         return f"{self.app_name}_{self.environment}"
-
-    # ---------------------------------
-    # cli build data
-    # ---------------------------------
-
-    app_name: str
-    """ The application's name """
-
-    app_version: str
-    """ The application's version """
-
-    commands: Dict
-    """ Internal commands. """

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -39,18 +39,43 @@ class CliContext(NamedTuple):
     # ---------------------------------
 
     def get_key_file(self) -> Path:
+        """Get the location of the key file for decrypting secrets
+
+        Returns:
+            Path: location of the key file
+        """
         return Path(self.configuration_dir, "key")
 
     def get_generated_configuration_dir(self) -> Path:
+        """Get the directory containing the generated configuration
+
+        Returns:
+            Path: directory of generated configuration
+        """
         return self.configuration_dir.joinpath(".generated")
 
     def get_app_configuration_file(self) -> Path:
+        """Get the location of the configuration file
+
+        Returns:
+            Path: location of the configuration file
+        """
         return self.configuration_dir.joinpath(f"{self.app_name.lower()}.yml")
 
     def get_templates_dir(self) -> Path:
+        """Get the directory of the raw configuration templates
+
+        Returns:
+            Path: directory of configuration templates
+        """
         return self.configuration_dir.joinpath("templates")
 
     def get_project_name(self) -> str:
+        """Get a unique name for the application and environment
+
+        Returns:
+            str: the project name
+        """
         return f"{self.app_name}_{self.environment}"
 
     # ---------------------------------

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -100,14 +100,16 @@ class DockerComposeOrchestrator(Orchestrator):
     """
 
     def __init__(
-        self, docker_compose_file: Path, docker_compose_override_files: Iterable[Path]
+        self,
+        docker_compose_file: Path,
+        docker_compose_override_files: Iterable[Path] = [],
     ):
         """
         Creates a new instance.
 
         Args:
             docker_compose_file (Path): Path to a `docker-compose.yml` file relative to the generated configuration directory.
-            docker_compose_override_files (Iterable[Path]): Paths to any additional docker-compose override files relative to the generated configuration directory.
+            docker_compose_override_files (Iterable[Path], optional): Paths to any additional docker-compose override files relative to the generated configuration directory.
         """
         self.docker_compose_file = docker_compose_file
         self.docker_compose_override_files = docker_compose_override_files
@@ -186,14 +188,16 @@ class DockerSwarmOrchestrator(Orchestrator):
     """
 
     def __init__(
-        self, docker_compose_file: Path, docker_compose_override_files: Iterable[Path]
+        self,
+        docker_compose_file: Path,
+        docker_compose_override_files: Iterable[Path] = [],
     ):
         """
         Creates a new instance.
 
         Args:
             docker_compose_file (Path): Path to a `docker-compose.yml` file relative to the generated configuration directory.
-            docker_compose_override_files (Iterable[Path]): Paths to any additional docker-compose override files relative to the generated configuration directory.
+            docker_compose_override_files (Iterable[Path], optional): Paths to any additional docker-compose override files relative to the generated configuration directory.
         """
         self.docker_compose_file = docker_compose_file
         self.docker_compose_override_files = docker_compose_override_files

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -167,7 +167,7 @@ class DockerComposeOrchestrator(Orchestrator):
         docker_compose_command = [
             "docker-compose",
             "--project-name",
-            cli_context.project_name,
+            cli_context.get_project_name(),
         ]
 
         compose_files = decrypt_files(
@@ -225,7 +225,7 @@ class DockerSwarmOrchestrator(Orchestrator):
         def logs(ctx, service):
             cli_context = ctx.obj
             command = ["docker", "service", "logs", "--follow"]
-            command.append(f"{cli_context.project_name}_{service}")
+            command.append(f"{cli_context.get_project_name()}_{service}")
             result = self.__exec_command(command)
             sys.exit(result.returncode)
 
@@ -254,7 +254,7 @@ class DockerSwarmOrchestrator(Orchestrator):
     ) -> CompletedProcess:
         command = ["docker", "stack"]
         command.extend(subcommand)
-        command.append(cli_context.project_name)
+        command.append(cli_context.get_project_name())
         return self.__exec_command(command)
 
     def __exec_command(self, command: str) -> CompletedProcess:
@@ -276,12 +276,12 @@ def decrypt_files(
     compose_files.extend(docker_compose_override_files)
     # turn relative paths into absolute paths
     compose_files = [
-        cli_context.generated_configuration_dir.joinpath(relative_path)
+        cli_context.get_generated_configuration_dir().joinpath(relative_path)
         for relative_path in compose_files
     ]
 
     # decrypt files if key is available
-    key_file = cli_context.key_file
+    key_file = cli_context.get_key_file()
     decrypted_files = [
         decrypt_file(encrypted_file, key_file) for encrypted_file in compose_files
     ]

--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -15,7 +15,7 @@
 
 # Variables are defaulted so that they can be overridden at runtime if desired
 MOUNTED_CONFIG_DIR="{{ '${' }}{{ app_name }}_CONFIG_DIR:-{{ cli_context.configuration_dir }}{{ '}' }}"
-MOUNTED_GENERATED_CONFIG_DIR="{{ '${' }}{{ app_name }}_GENERATED_CONFIG_DIR:-{{ cli_context.generated_configuration_dir }}{{ '}' }}"
+MOUNTED_GENERATED_CONFIG_DIR="{{ '${' }}{{ app_name }}_GENERATED_CONFIG_DIR:-{{ cli_context.get_generated_configuration_dir() }}{{ '}' }}"
 MOUNTED_DATA_DIR="{{ '${' }}{{ app_name }}_DATA_DIR:-{{ cli_context.data_dir}}{{ '}' }}"
 ENVIRONMENT="{{ '${' }}{{ app_name }}_ENVIRONMENT:-{{ cli_context.environment}}{{ '}' }}"
 
@@ -31,9 +31,6 @@ function main()
         --rm \
         --interactive \
         --tty \
-{% for name, value in desired_environment.items() %}
-        --env {{ name }}="{{ value }}" \
-{% endfor %}
 {% for name, value in cli_context.additional_env_variables %}
         --env {{ name }}="{{ value }}" \
 {% endfor %}

--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -1,42 +1,23 @@
 #!/usr/bin/env bash
 
 ##
- # Wrapper to launch the {{ app_name.capitalize() }} container.
+ # Wrapper to launch {{ app_name }}.
  #
  # Application version: v{{ app_version }}
- # Template version: v1.0
  # _____________________________________________________________________________
  #
- # Created by brightSPARK Labs
- # www.brightsparklabs.com
+ # Generated at {{ current_datetime }}
  ##
 
 # ------------------------------------------------------------------------------
-# CONSTANT
+# VARIABLES
 # ------------------------------------------------------------------------------
 
-# directory containing this script
-readonly BASE_DIR=$(cd "$(dirname $0)" && pwd)
-
-# {{ app_name.lower() }} home directory on the physical host
-readonly {{ app_name.upper() }}_EXT_{{ app_name.upper() }}_HOME=${BASE_DIR}
-export {{ app_name.upper() }}_EXT_{{ app_name.upper() }}_HOME
-
-# {{ app_name.lower() }} version
-readonly {{ app_name.upper() }}_VERSION={{ app_version }}
-
-# {{ app_name.lower() }} root directory on the physical host
-readonly {{ app_name.upper() }}_EXT_{{ app_name.upper() }}_ROOT=$(cd "${BASE_DIR}/.." && pwd)
-export {{ app_name.upper() }}_EXT_{{ app_name.upper() }}_ROOT
-
-# location to mount the physical host's root directory in the container
-readonly {{ app_name.upper() }}_EXT_HOST_ROOT=/mnt/host
-export {{ app_name.upper() }}_EXT_HOST_ROOT
-
-# mandatory environment variables in {{ app_name.lower() }}-host.env file
-declare -ra MANDATORY_ENV_VARIABLES=(
-    {{ app_name.upper() }}_EXT_DATA_DIR
-)
+# Variables are defaulted so that they can be overridden at runtime if desired
+MOUNTED_CONFIG_DIR="{{ '${' }}{{ app_name }}_CONFIG_DIR:-{{ cli_context.configuration_dir }}{{ '}' }}"
+MOUNTED_GENERATED_CONFIG_DIR="{{ '${' }}{{ app_name }}_GENERATED_CONFIG_DIR:-{{ cli_context.generated_configuration_dir }}{{ '}' }}"
+MOUNTED_DATA_DIR="{{ '${' }}{{ app_name }}_DATA_DIR:-{{ cli_context.data_dir}}{{ '}' }}"
+ENVIRONMENT="{{ '${' }}{{ app_name }}_ENVIRONMENT:-{{ cli_context.environment}}{{ '}' }}"
 
 # ------------------------------------------------------------------------------
 # LOGIC
@@ -44,43 +25,44 @@ declare -ra MANDATORY_ENV_VARIABLES=(
 
 function main()
 {
-    # if running 'configure' then use a reduced environment
-    local _env=
-    if [[ "${1:-}" == configure ]]; then
-        _env="--volume /:${{ "{" + app_name.upper() }}_EXT_HOST_ROOT} --env {{ app_name.upper() }}_EXT_HOST_ROOT"
-    else
-        [[ -r "${BASE_DIR}/{{ app_name.lower() }}-host.env" ]] || {
-            echo "ERROR: System has not been configured. Please run [$(dirname $0 | head -1)/{{ app_name.lower() }} configure]"
-            exit 1
-        }
-        # read environment variables
-        source "${BASE_DIR}/{{ app_name.lower() }}-host.env"
-        # check mandatory environment variables
-        for _env_var in ${MANDATORY_ENV_VARIABLES[@]}; do
-            [[ -z ${!_env_var:-} ]] && print_error_and_exit "Environment variable [${_env_var}] has not been defined."
-        done
 
-        # ensure variables are passed through to docker container
-        for _env_var in $(set | grep '^{{ app_name.upper() }}_EXT_' | cut -f1 -d=); do
-            _env="${_env} --env ${_env_var}=${!_env_var}"
-        done
-
-        # mount the data dir
-        _env="${_env} --volume ${{ "{" + app_name.upper() }}_EXT_DATA_DIR}:${{ "{" + app_name.upper() }}_EXT_DATA_DIR}"
-    fi
-
-    # launch container
-    exec docker run \
-        --name {{ app_name.lower() }} \
-        -it \
+    docker run \
+        --name {{ app_name }}_{{ cli_context.environment }}_launcher_$(date +%s) \
         --rm \
-        --network=host \
-        ${_env} \
-        --volume /etc/timezone:/etc/timezone:ro \
+        --interactive \
+        --tty \
+{% for name, value in desired_environment.items() %}
+        --env {{ name }}="{{ value }}" \
+{% endfor %}
+{% for name, value in cli_context.additional_env_variables %}
+        --env {{ name }}="{{ value }}" \
+{% endfor %}
+{% for name, path in cli_context.additional_data_dirs %}
+        --volume "{{ path }}={{ path }}" \
+{% endfor %}
         --volume /var/run/docker.sock:/var/run/docker.sock \
-        --volume "${{ "{" + app_name.upper() }}_EXT_{{ app_name.upper() }}_ROOT}":"${{ "{" + app_name.upper() }}_EXT_{{ app_name.upper() }}_ROOT}" \
-        --env {{ app_name.upper() }}_EXT_{{ app_name.upper() }}_HOME \
-        brightsparklabs/{{ app_name.lower() }}:{{app_version}} $@
+        --env {{ app_name }}_CONFIG_DIR="${MOUNTED_CONFIG_DIR}" \
+        --volume "${MOUNTED_CONFIG_DIR}:${MOUNTED_CONFIG_DIR}" \
+        --env {{ app_name }}_GENERATED_CONFIG_DIR="${MOUNTED_GENERATED_CONFIG_DIR}" \
+        --volume "${MOUNTED_GENERATED_CONFIG_DIR}:${MOUNTED_GENERATED_CONFIG_DIR}" \
+        --env {{ app_name }}_DATA_DIR="${MOUNTED_DATA_DIR}" \
+        --volume "${MOUNTED_DATA_DIR}:${MOUNTED_DATA_DIR}" \
+        --env {{ app_name }}_ENVIRONMENT="${ENVIRONMENT}" \
+        {{ configuration.docker_image }}:{{ app_version }} \
+            --configuration-dir "${MOUNTED_CONFIG_DIR}" \
+            --data-dir "${MOUNTED_DATA_DIR}" \
+            --environment "${ENVIRONMENT}" \
+{% for name, path in cli_context.additional_data_dirs %}
+            --additional-data-dir {{ name }}="{{ path }}" \
+{% endfor %}
+{% for name, value in cli_context.additional_env_variables %}
+            --additional-env-var {{ name }}="{{ value }}" \
+{% endfor %}
+{% if cli_context.debug %}
+            --debug \
+{% endif %}
+            $@
+
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- stopped relaunching, which also untangled the stderr and stdout streams
- moved the output launcher script to j2 template
- moved 'calculated' values of CliContext to the object itself, rather than on initialisation.
- appcli commands now have better validation checks on configuration directories before allowing run. Also allows for 'force' behaviour on non-blocking errors.