### PR TITLE
TERA-255: Modify the output launcher script to launch the cli contain…

### DIFF
--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -46,6 +46,7 @@ function main()
         --env {{ app_name }}_DATA_DIR="${MOUNTED_DATA_DIR}" \
         --volume "${MOUNTED_DATA_DIR}:${MOUNTED_DATA_DIR}" \
         --env {{ app_name }}_ENVIRONMENT="${ENVIRONMENT}" \
+        --network host \
         {{ configuration.docker_image }}:{{ app_version }} \
             --configuration-dir "${MOUNTED_CONFIG_DIR}" \
             --data-dir "${MOUNTED_DATA_DIR}" \


### PR DESCRIPTION
…er on the host network. This gives it access to containers on other docker networks and the broader host.

This is also advantageous for the `init keycloak` command, as it requires a url accessible by the launched cli container. Before this PR, it would only be able to hit the docker host via IP. Post this PR, it can hit anything that the docker host can.