### PR TITLE
Feature/appcli 36 pass through credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint: venv
 	${PYTHON} -m flake8 --ignore=E501,W503 --exclude=appcli/__init__.py appcli tests
 
 isort: venv
-	${PYTHON} -m isort
+	${PYTHON} -m isort .
 
 format: isort
 	${PYTHON} -m black .

--- a/README.md
+++ b/README.md
@@ -113,10 +113,23 @@ variables within the `settings.yml` file as described in the Usage section.
     # sh
     docker build -t brightsparklabs/myapp --build-arg APP_VERSION=latest .
 
+### (Optional) Login to private docker registries and pass through credentials
+
+It is possible to login to private docker registries on the host, and pass through
+credentials to the cli container run by the launcher script. This enables pulling
+and running docker images from private docker registries.
+
+Login using:
+
+    docker login $REGISTRY_URL
+
+The credentials file path, default `~/.docker/config.json`, can be passed as
+an option `--docker-credentials-file` or `-o` to the `myapp` container.
+
 ### View the installer script
 
     # sh
-    docker run --rm brightsparklabs/myapp:<version> install
+    docker run --rm brightsparklabs/myapp:<version> --docker-credentials-file ~/.docker/config.json install
 
 While it is not mandatory to view the script before running, it is highly recommended.
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Docker-in-Docker). This is generally managed via a `docker-compose.yml` file.
 
 The library exposes the following environment variables to the `docker-compose.yml` file:
 
-- `APP_VERSION` - the version of containers to launch
-- `<APP_NAME>_CONFIG_DIR` - the directory containing configuration files
-- `<APP_NAME>_DATA_DIR` - the directory containing data produced by the system.
+- `APP_VERSION` - the version of containers to launch.
+- `<APP_NAME>_CONFIG_DIR` - the directory containing configuration files.
+- `<APP_NAME>_DATA_DIR` - the directory containing data produced/consumed by the system.
 - `<APP_NAME>_GENERATED_CONFIG_DIR` - the directory containing configuration files generated from
   the templates in `<APP_NAME>_CONFIG_DIR`.
-- `<APP_NAME>_ENVIRONMENT` - the deployment environment of the application. For example `production`
-  or `staging`. This allows multiple instances of the application to run on the same docker daemon.
-  Defaults to 'production'.
+- `<APP_NAME>_ENVIRONMENT` - the deployment environment the system is running in. For example
+  `production` or `staging`. This allows multiple instances of the application to run on the same
+  Docker daemon. Defaults to `production`.
 
 The `docker-compose.yml` can be templated by renaming to `docker-compose.yml.j2`, and setting
 variables within the `settings.yml` file as described in the Usage section.
@@ -113,22 +113,25 @@ variables within the `settings.yml` file as described in the Usage section.
     # sh
     docker build -t brightsparklabs/myapp --build-arg APP_VERSION=latest .
 
-### (Optional) Login to private docker registries and pass through credentials
+### (Optional) Login to private Docker registries and pass through credentials
 
-It is possible to login to private docker registries on the host, and pass through
-credentials to the cli container run by the launcher script. This enables pulling
-and running docker images from private docker registries.
+It is possible to login to private Docker registries on the host, and pass through credentials to
+the CLI container run by the launcher script. This enables pulling and running Docker images from
+private Docker registries.
 
 Login using:
 
-    docker login $REGISTRY_URL
+    docker login ${REGISTRY_URL}
 
-The credentials file path, default `~/.docker/config.json`, can be passed as
-an option `--docker-credentials-file` or `-o` to the `myapp` container.
+The credentials file path can be passed as an option via `--docker-credentials-file` or `-p` to the
+`myapp` container.
 
 ### View the installer script
 
     # sh
+    docker run --rm brightsparklabs/myapp:<version> install
+
+    # or if using a private registry for images
     docker run --rm brightsparklabs/myapp:<version> --docker-credentials-file ~/.docker/config.json install
 
 While it is not mandatory to view the script before running, it is highly recommended.

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -103,6 +103,13 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         default="production",
     )
     @click.option(
+        "--docker-credentials-file",
+        "-o",
+        help="Path to the Docker credentials file (config.json) on the host for private docker registries.",
+        required=False,
+        type=Path,
+    )
+    @click.option(
         "--additional-data-dir",
         "-a",
         help="Additional data directory to expose to launcher container. Can be specified multiple times.",
@@ -125,6 +132,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         configuration_dir,
         data_dir,
         environment,
+        docker_credentials_file,
         additional_data_dir,
         additional_env_var,
     ):
@@ -138,6 +146,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             additional_data_dirs=additional_data_dir,
             additional_env_variables=additional_env_var,
             environment=environment,
+            docker_credentials_file=docker_credentials_file,
             subcommand_args=ctx.obj,
             debug=debug,
             app_name=APP_NAME,

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -81,7 +81,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
     @click.option(
         "--configuration-dir",
         "-c",
-        help="Directory to read configuration files from.",
+        help="Directory containing configuration files.",
         type=Path,
         cls=NotRequiredOn,
         not_required_on=("install"),
@@ -89,7 +89,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
     @click.option(
         "--data-dir",
         "-d",
-        help="Directory to store data to.",
+        help="Directory containing data produced/consumed by the system.",
         type=Path,
         cls=NotRequiredOn,
         not_required_on=("install"),
@@ -97,15 +97,15 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
     @click.option(
         "--environment",
         "-t",
-        help="Environment to run. Defaults to 'production'.",
+        help="Deployment environment the system is running in. Defaults to `production`.",
         required=False,
         type=click.STRING,
         default="production",
     )
     @click.option(
         "--docker-credentials-file",
-        "-o",
-        help="Path to the Docker credentials file (config.json) on the host for private docker registries.",
+        "-p",
+        help="Path to the Docker credentials file (config.json) on the host for connecting to private Docker registries.",
         required=False,
         type=Path,
     )

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -28,7 +28,7 @@ class CliContext(NamedTuple):
     environment: str
     """ Environment to run. """
 
-    docker_credentials_file: str
+    docker_credentials_file: Path
     """ Path to the Docker credentials file (config.json) on the host for private docker registries. """
 
     subcommand_args: tuple

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -28,6 +28,9 @@ class CliContext(NamedTuple):
     environment: str
     """ Environment to run. """
 
+    docker_credentials_file: str
+    """ Path to the Docker credentials file (config.json) on the host for private docker registries. """
+
     subcommand_args: tuple
     """ Arguments passed to CLI subcommand. """
 

--- a/appcli/templates/installer.j2
+++ b/appcli/templates/installer.j2
@@ -45,6 +45,9 @@ function generate_launcher()
             --configuration-dir "{{ cli_context.configuration_dir }}" \
             --data-dir "{{ cli_context.data_dir }}" \
             --environment "{{ cli_context.environment }}" \
+{% if cli_context.docker_credentials_file %}
+            --docker-credentials-file "{{ cli_context.docker_credentials_file }}" \
+{% endif %}
 {% for name, path in cli_context.additional_data_dirs %}
             --additional-data-dir {{ name }}="{{ path }}" \
 {% endfor %}

--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -31,6 +31,9 @@ function main()
         --rm \
         --interactive \
         --tty \
+{% if cli_context.docker_credentials_file %}
+        --volume "{{ cli_context.docker_credentials_file }}:/root/.docker/config.json" \
+{% endif %}
 {% for name, value in cli_context.additional_env_variables %}
         --env {{ name }}="{{ value }}" \
 {% endfor %}

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -171,6 +171,7 @@ def create_cli_context(tmpdir, app_version: str = "0.0.0") -> CliContext:
         additional_data_dirs=None,
         additional_env_variables=None,
         environment="test",
+        docker_credentials_file=None,
         subcommand_args=None,
         debug=True,
         app_name=APP_NAME,


### PR DESCRIPTION
Allow passing through docker credentials to the cli container when launching by the launch script. The install script will also pass this through to the launch script.

Resolves #29 