### PR TITLE
Feature/appcli 43 support onceoff runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A library for adding CLI interfaces to applications in the brightSPARK Labs styl
 ## Overview
 
 This library can be leveraged to add a standardised CLI capability to applications to handle system
-lifecycle events (start, shutdown, configure, migrate, etc).
+lifecycle events (start, shutdown, configure, migrate, etc), and to run one-off commands within
+the appcli ecosystem (task).
 
 The CLI is designed to run within a Docker container and launch other Docker containers (i.e.
 Docker-in-Docker). This is generally managed via a `docker-compose.yml` file.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A library for adding CLI interfaces to applications in the brightSPARK Labs styl
 
 This library can be leveraged to add a standardised CLI capability to applications to:
 
-- handle system lifecycle events for services (`service [start|shutdown]`),
-- allow running arbitrary short-lived tasks (`task run`),
-- manage configuration (`configure`),
-- upgrade to a newer version of the application (`upgrade|migrate`),
-- and more...
+- Handle system lifecycle events for services (`service [start|shutdown]`).
+- Allow running arbitrary short-lived tasks (`task run`).
+- Manage configuration (`configure`).
+- Upgrade to a newer version of the application (`upgrade|migrate`).
+- And more.
 
 The CLI is designed to run within a Docker container and launch other Docker containers (i.e.
 Docker-in-Docker). This is generally managed via a `docker-compose.yml` file.
@@ -194,30 +194,29 @@ This section details what commands and options are available.
 
 To be used in conjunction with your application `./myapp <command>` e.g. `./myapp start`
 
-| Command      | Description                                                                          |
-| ------------ | ------------------------------------------------------------------------------------ |
-| configure    | Configures the application.                                                          |
-| encrypt      | Encrypts the specified string.                                                       |
-| init         | Initialises the application.                                                         |
-| launcher     | Outputs an appropriate launcher bash script.                                         |
-| migrate      | Migrates the configuration of the application to a newer version.                    |
-| orchestrator | Perform docker orchestration                                                         |
-| service      | Lifecycle management commands for application services.                              |
-| task         | Commands for application tasks.                                                      |
-| upgrade      | Upgrades the application configuration to work with the current application version. |
+| Command      | Description                                                       |
+| ------------ | ----------------------------------------------------------------- |
+| configure    | Configures the application.                                       |
+| encrypt      | Encrypts the specified string.                                    |
+| init         | Initialises the application.                                      |
+| launcher     | Outputs an appropriate launcher bash script.                      |
+| migrate      | Migrates the configuration of the application to a newer version. |
+| orchestrator | Perform docker orchestration                                      |
+| service      | Lifecycle management commands for application services.           |
+| task         | Commands for application tasks.                                   |
 
 ### Options
 
-| Option                             | Description                                                                                                        |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| --debug                            | Enables debug level logging.                                                                                       |
-| -c, --configuration-dir PATH       | Directory containing configuration files. [This is required unless subcommand is one of: install.                  |
-| -d, --data-dir PATH                | Directory containing data p roduced/consumed by the system. This is required unless subcommand is one of: install. |
-| -t, --environment TEXT             | Deployment environment the system is running in. Defaults to `production`.                                         |
-| -p, --docker-credentials-file PATH | Path to the Docker credentials file (config.json) on the host for connecting to private Docker registries.         |
-| -a, --additional-data-dir TEXT     | Additional data directory to expose to launcher container. Can be specified multiple times.                        |
-| -e, --additional-env-var TEXT      | Additional environment variables to expose to launcher container. Can be specified multiple times.                 |
-| --help                             | Show the help message and exit.                                                                                    |
+| Option                             | Description                                                                                                         |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| --debug                            | Enables debug level logging.                                                                                        |
+| -c, --configuration-dir PATH       | Directory containing configuration files. [This is required unless subcommand is one of: `install`.                 |
+| -d, --data-dir PATH                | Directory containing data produced/consumed by the system. This is required unless subcommand is one of: `install`. |
+| -t, --environment TEXT             | Deployment environment the system is running in. Defaults to `production`.                                          |
+| -p, --docker-credentials-file PATH | Path to the Docker credentials file (config.json) on the host for connecting to private Docker registries.          |
+| -a, --additional-data-dir TEXT     | Additional data directory to expose to launcher container. Can be specified multiple times.                         |
+| -e, --additional-env-var TEXT      | Additional environment variables to expose to launcher container. Can be specified multiple times.                  |
+| --help                             | Show the help message and exit.                                                                                     |
 
 #### Command: `configure`
 
@@ -282,7 +281,7 @@ No commands available
 
 #### Command: `migrate`
 
-Migrates the application configuration to work with the current application version. Currently aliased with 'upgrade'.
+Migrates the application configuration to work with the current application version.
 usage `./myapp migrate [OPTIONS]`
 
 | Command | Description |
@@ -334,24 +333,9 @@ usage `./myapp task [OPTIONS] COMMAND [ARGS]`
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
 
-#### Command: `upgrade`
-
-Upgrades the application configuration to work with the current application version. Currently aliased with 'migrate'.
-usage `./myapp upgrade [OPTIONS]`
-
-| Command | Description |
-| ------- | ----------- |
-
-
-No commands available
-
-| Option | Description                     |
-| ------ | ------------------------------- |
-| --help | Show the help message and exit. |
-
 ### Usage within scripts and cron
 
-By default, the generated `appcli` launcher script will run the cli container with a virtual terminal session (tty).
+By default, the generated `appcli` launcher script will run the CLI container with a virtual terminal session (tty).
 This may interfere with crontab entries or scripts that use the appcli launcher.
 
 To disable tty when running the launcher script, set `NO_TTY` environment variable to `true`.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ A library for adding CLI interfaces to applications in the brightSPARK Labs styl
 
 ## Overview
 
-This library can be leveraged to add a standardised CLI capability to applications to handle system
-lifecycle events (start, shutdown, configure, migrate, etc), and to run one-off commands within
-the appcli ecosystem (task).
+This library can be leveraged to add a standardised CLI capability to applications to:
+
+- handle system lifecycle events for services (`service [start|shutdown]`),
+- allow running arbitrary short-lived tasks (`task run`),
+- manage configuration (`configure`),
+- upgrade to a newer version of the application (`upgrade|migrate`),
+- and more...
 
 The CLI is designed to run within a Docker container and launch other Docker containers (i.e.
 Docker-in-Docker). This is generally managed via a `docker-compose.yml` file.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ variables within the `settings.yml` file as described in the Installation sectio
                 docker_compose_task_override_directory = Path(
                     "docker-compose.tasks.override.d/"
                 ),
-                ),
+            ),
             mandatory_additional_data_dirs=["EXTRA_DATA",],
             mandatory_additional_env_variables=["ENV_VAR_2",],
         )

--- a/README.md
+++ b/README.md
@@ -65,8 +65,13 @@ variables within the `settings.yml` file as described in the Installation sectio
             baseline_templates_dir=Path(BASE_DIR, 'resources/templates/baseline'),
             configurable_templates_dir=Path(BASE_DIR, 'resource/templates/configurable'),
             orchestrator=appcli.DockerComposeOrchestrator(
-              Path('docker-compose.yml')
-            ),
+                docker_compose_file = Path("docker-compose.yml"),
+                docker_compose_override_directory = Path("docker-compose.override.d/"),
+                docker_compose_task_file = Path("docker-compose.tasks.yml"),
+                docker_compose_task_override_directory = Path(
+                    "docker-compose.tasks.override.d/"
+                ),
+                ),
             mandatory_additional_data_dirs=["EXTRA_DATA",],
             mandatory_additional_env_variables=["ENV_VAR_2",],
         )
@@ -182,31 +187,33 @@ main entrypoint to all appcli functions for managing your application.
 This section details what commands and options are available.
 
 ### Top-level Commands
+
 To be used in conjunction with your application `./myapp <command>` e.g. `./myapp start`
 
-| Command      | Description                                                       |
-| ------------ | ----------------------------------------------------------------- |
-| configure    | Configures the application.                                       |
-| encrypt      | Encrypts the specified string.                                    |
-| init         | Initialises the application.                                      |
-| launcher     | Outputs an appropriate launcher bash script.                      |
-| logs         | Prints logs from all services.                                    |
-| migrate      | Migrates the configuration of the application to a newer version. |
-| orchestrator | Perform docker orchestration                                      |
-| shutdown     | Shuts down the system.                                            |
-| start        | Starts the system.                                                |
+| Command      | Description                                                                          |
+| ------------ | ------------------------------------------------------------------------------------ |
+| configure    | Configures the application.                                                          |
+| encrypt      | Encrypts the specified string.                                                       |
+| init         | Initialises the application.                                                         |
+| launcher     | Outputs an appropriate launcher bash script.                                         |
+| migrate      | Migrates the configuration of the application to a newer version.                    |
+| orchestrator | Perform docker orchestration                                                         |
+| service      | Lifecycle management commands for application services.                              |
+| task         | Commands for application tasks.                                                      |
+| upgrade      | Upgrades the application configuration to work with the current application version. |
 
 ### Options
-| Option                             | Description                                                                                                          |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| --debug                            | Enables debug level logging.                                                                                         |
-| -c, --configuration-dir PATH       | Directory containing configuration files. [This is required unless subcommand is one of: install.                    |
-| -d, --data-dir PATH                | Directory containing data p roduced/consumed by the system. This is required unless  subcommand is  one of: install. |
-| -t, --environment TEXT             | Deployment environment the system is running in. Defaults to `production`.                                           |
-| -p, --docker-credentials-file PATH | Path to the Docker credentials file (config.json) on the host for connecting to private Docker registries.           |
-| -a, --additional-data-dir TEXT     | Additional data directory to expose to launcher container. Can be specified multiple times.                          |
-| -e, --additional-env-var TEXT      | Additional environment variables to expose to launcher container. Can be specified multiple times.                   |
-| --help                             | Show the help message and exit.                                                                                      |
+
+| Option                             | Description                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| --debug                            | Enables debug level logging.                                                                                       |
+| -c, --configuration-dir PATH       | Directory containing configuration files. [This is required unless subcommand is one of: install.                  |
+| -d, --data-dir PATH                | Directory containing data p roduced/consumed by the system. This is required unless subcommand is one of: install. |
+| -t, --environment TEXT             | Deployment environment the system is running in. Defaults to `production`.                                         |
+| -p, --docker-credentials-file PATH | Path to the Docker credentials file (config.json) on the host for connecting to private Docker registries.         |
+| -a, --additional-data-dir TEXT     | Additional data directory to expose to launcher container. Can be specified multiple times.                        |
+| -e, --additional-env-var TEXT      | Additional environment variables to expose to launcher container. Can be specified multiple times.                 |
+| --help                             | Show the help message and exit.                                                                                    |
 
 #### Command: `configure`
 
@@ -226,21 +233,23 @@ usage `./myapp configure [OPTIONS] COMMAND [ARGS]`
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
 
-
 #### Command: `encrypt`
+
 Encrypts the specified string.
 usage `./myapp encrypt [OPTIONS] TEXT`
 
 | Command | Description |
 | ------- | ----------- |
+
+
 No commands available
 
 | Option | Description                     |
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
 
-
 #### Command: `init`
+
 Initialises the application.
 usage `./myapp init [OPTIONS] COMMAND [ARGS]`
 
@@ -253,86 +262,88 @@ usage `./myapp init [OPTIONS] COMMAND [ARGS]`
 | --help | Show the help message and exit. |
 
 #### Command: `launcher`
+
 Outputs an appropriate launcher bash script to stdout.
 usage `./myapp launcher [OPTIONS]`
 
 | Command | Description |
 | ------- | ----------- |
+
+
 No commands available
 
 | Option | Description                     |
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
-
-
-#### Command: `logs`
-Prints logs from all services (or the ones specified).
-usage `./myapp logs [OPTIONS] [SERVICE]`
-
-| Command | Description |
-| ------- | ----------- |
-No commands available
-
-| Option | Description                     |
-| ------ | ------------------------------- |
-| --help | Show the help message and exit. |
-
 
 #### Command: `migrate`
-Migrates the application configuration to work with the current application version.
+
+Migrates the application configuration to work with the current application version. Currently aliased with 'upgrade'.
 usage `./myapp migrate [OPTIONS]`
 
 | Command | Description |
 | ------- | ----------- |
+
+
 No commands available
 
 | Option | Description                     |
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
 
-
 #### Command: `orchestrator`
-Perform docker orchestration
+
+Perform tasks defined by the orchestrator.
 usage `./myapp orchestrator [OPTIONS] COMMAND [ARGS]`
 
-| Command | Description                    |
-| ------- | ------------------------------ |
-| compose | Runs a docker compose command. |
-| ps      | List the status of services    |
+All commands are defined within the orchestrators themselves. Run `./myapp orchestrator` to list available commands.
 
 | Option | Description                    |
 | ------ | ------------------------------ |
 | --help | Show the help message and exit |
 
+#### Command: `service`
 
-#### Command: `shutdown`
-Shuts down the system.
-usage `./myapp shutdown [OPTIONS]`
+Runs application services. These are the long-running services which should only exit on command.
+usage `./myapp service [OPTIONS] COMMAND [ARGS]`
+
+| Command  | Description                    |
+| -------- | ------------------------------ |
+| logs     | Prints logs from all services. |
+| shutdown | Shuts down the system.         |
+| start    | Starts the system.             |
+
+| Option | Description                     |
+| ------ | ------------------------------- |
+| --help | Show the help message and exit. |
+
+#### Command: `task`
+
+Runs application tasks. These are short-lived services which should exit when the task is complete.
+usage `./myapp task [OPTIONS] COMMAND [ARGS]`
+
+| Command | Description                        |
+| ------- | ---------------------------------- |
+| run     | Runs a specified application task. |
+
+| Option | Description                     |
+| ------ | ------------------------------- |
+| --help | Show the help message and exit. |
+
+#### Command: `upgrade`
+
+Upgrades the application configuration to work with the current application version. Currently aliased with 'migrate'.
+usage `./myapp upgrade [OPTIONS]`
 
 | Command | Description |
 | ------- | ----------- |
+
+
 No commands available
 
-| Option  | Description                                    |
-| ------- | ---------------------------------------------- |
-| --force | Force shutdown even if validation checks fail. |
-| --help  | Show this message and exit.                    |
-
-
-#### Command: `start`
-Starts the system.
-usage `./myapp  start [OPTIONS]`
-
-| Command | Description |
-| ------- | ----------- |
-No commands available
-
-| Option  | Description                                 |
-| ------- | ------------------------------------------- |
-| --force | Force start even if validation checks fail. |
-| --help  | Show this message and exit.                 |
-
-
+| Option | Description                     |
+| ------ | ------------------------------- |
+| --help | Show the help message and exit. |
 
 ### Usage within scripts and cron
 

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -21,6 +21,7 @@ from tabulate import tabulate
 
 # local libraries
 from appcli.commands.configure_cli import ConfigureCli
+from appcli.commands.debug_cli import DebugCli
 from appcli.commands.encrypt_cli import EncryptCli
 from appcli.commands.init_cli import InitCli
 from appcli.commands.install_cli import InstallCli
@@ -60,6 +61,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
     default_commands = {}
     for cli_class in (
         ConfigureCli,
+        DebugCli,
         EncryptCli,
         InitCli,
         InstallCli,

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -178,7 +178,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
 
         # For the `installer`/`launcher` commands, no further output/checks required.
         if ctx.invoked_subcommand in ("launcher", "install"):
-            # Don't execute this function any further, continue to run subcommand with the current cli context
+            # Don't execute this function any further, continue to run subcommand with the current CLI context
             return
 
         check_docker_socket()
@@ -222,7 +222,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
             )
 
     def run():
-        """Run the entry-point click cli command"""
+        """Run the entry-point click CLI command"""
         cli(  # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
             prog_name=configuration.app_name
         )

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -26,8 +26,9 @@ from appcli.commands.encrypt_cli import EncryptCli
 from appcli.commands.init_cli import InitCli
 from appcli.commands.install_cli import InstallCli
 from appcli.commands.launcher_cli import LauncherCli
-from appcli.commands.main_cli import MainCli
 from appcli.commands.migrate_cli import MigrateCli
+from appcli.commands.service_cli import ServiceCli
+from appcli.commands.task_cli import TaskCli
 from appcli.functions import error_and_exit, extract_valid_environment_variable_names
 from appcli.logger import enable_debug_logging, logger
 from appcli.models.cli_context import CliContext
@@ -66,8 +67,9 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         InitCli,
         InstallCli,
         LauncherCli,
-        MainCli,
         MigrateCli,
+        ServiceCli,
+        TaskCli,
     ):
         commands = cli_class(configuration).commands
         default_commands.update(**commands)

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -10,7 +10,6 @@ www.brightsparklabs.com
 """
 
 # standard library
-from appcli.variables_manager import VariablesManager
 import difflib
 
 # vendor libraries

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -160,25 +160,6 @@ class ConfigureCli:
                 # remove superfluous \n characters added by unified_diff
                 print(line.rstrip())
 
-        @configure.command(
-            hidden=True,
-            help="Prints detailed information about the current configuration.",
-        )
-        @click.pass_context
-        def info(ctx):
-            cli_context: CliContext = ctx.obj
-            print("=== CLI CONTEXT ===")
-            pprint(cli_context)
-            print("=== CONFIGURATION ===")
-            pprint(self.cli_configuration)
-            print("=== ORCHESTRATOR CONFIGURATION ===")
-            pprint(vars(self.cli_configuration.orchestrator))
-
-            app_config_file = cli_context.get_app_configuration_file()
-            variables_manager = VariablesManager(app_config_file)
-            print("=== VARIABLES ===")
-            pprint(variables_manager.get_all_variables())
-
         # Add the 'template' subcommand
         configure.add_command(ConfigureTemplateCli(self.cli_configuration).command)
 

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -10,6 +10,7 @@ www.brightsparklabs.com
 """
 
 # standard library
+from appcli.variables_manager import VariablesManager
 import difflib
 
 # vendor libraries
@@ -24,6 +25,7 @@ from appcli.git_repositories.git_repositories import confirm_config_dir_exists
 from appcli.logger import logger
 from appcli.models.cli_context import CliContext
 from appcli.models.configuration import Configuration
+from pprint import pprint
 
 # ------------------------------------------------------------------------------
 # CLASSES
@@ -157,6 +159,25 @@ class ConfigureCli:
             ):
                 # remove superfluous \n characters added by unified_diff
                 print(line.rstrip())
+
+        @configure.command(
+            hidden=True,
+            help="Prints detailed information about the current configuration.",
+        )
+        @click.pass_context
+        def info(ctx):
+            cli_context: CliContext = ctx.obj
+            print("=== CLI CONTEXT ===")
+            pprint(cli_context)
+            print("=== CONFIGURATION ===")
+            pprint(self.cli_configuration)
+            print("=== ORCHESTRATOR CONFIGURATION ===")
+            pprint(vars(self.cli_configuration.orchestrator))
+
+            app_config_file = cli_context.get_app_configuration_file()
+            variables_manager = VariablesManager(app_config_file)
+            print("=== VARIABLES ===")
+            pprint(variables_manager.get_all_variables())
 
         # Add the 'template' subcommand
         configure.add_command(ConfigureTemplateCli(self.cli_configuration).command)

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -25,7 +25,6 @@ from appcli.git_repositories.git_repositories import confirm_config_dir_exists
 from appcli.logger import logger
 from appcli.models.cli_context import CliContext
 from appcli.models.configuration import Configuration
-from pprint import pprint
 
 # ------------------------------------------------------------------------------
 # CLASSES

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -172,7 +172,7 @@ class ConfigureCli:
         """Ensures the system is in a valid state for 'configure get'.
 
         Args:
-            cli_context (CliContext): the current cli context
+            cli_context (CliContext): The current CLI context.
         """
         logger.info("Checking system configuration is valid before 'configure get' ...")
 

--- a/appcli/commands/debug_cli.py
+++ b/appcli/commands/debug_cli.py
@@ -29,8 +29,6 @@ class DebugCli:
     def __init__(self, configuration: Configuration):
         self.cli_configuration: Configuration = configuration
 
-        self.app_name = self.cli_configuration.app_name
-
         # ------------------------------------------------------------------------------
         # CLI METHODS
         # ------------------------------------------------------------------------------
@@ -47,7 +45,7 @@ class DebugCli:
             click.echo(ctx.get_help())
 
         @debug.command(
-            help="Prints debug information about the current cli context, configuration, and settings.",
+            help="Prints debug information about the current CLI context, configuration, and settings.",
         )
         @click.pass_context
         def info(ctx):

--- a/appcli/commands/debug_cli.py
+++ b/appcli/commands/debug_cli.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# # -*- coding: utf-8 -*-
+
+"""
+Common debug tasks.
+________________________________________________________________________________
+
+Created by brightSPARK Labs
+www.brightsparklabs.com
+"""
+
+# standard library
+from appcli.variables_manager import VariablesManager
+
+# vendor libraries
+import click
+
+
+# local libraries
+from appcli.models.cli_context import CliContext
+from appcli.models.configuration import Configuration
+from pprint import pprint
+
+# ------------------------------------------------------------------------------
+# CLASSES
+# ------------------------------------------------------------------------------
+
+
+class DebugCli:
+    def __init__(self, configuration: Configuration):
+        self.cli_configuration: Configuration = configuration
+
+        self.app_name = self.cli_configuration.app_name
+
+        # ------------------------------------------------------------------------------
+        # CLI METHODS
+        # ------------------------------------------------------------------------------
+
+        @click.group(
+            hidden=True, invoke_without_command=True, help="Common debugging tasks."
+        )
+        @click.pass_context
+        def debug(ctx):
+            if ctx.invoked_subcommand is not None:
+                # subcommand provided
+                return
+
+            click.echo(ctx.get_help())
+
+        @debug.command(
+            help="Prints debug information about the current cli context, configuration, and settings.",
+        )
+        @click.pass_context
+        def info(ctx):
+            cli_context: CliContext = ctx.obj
+            app_config_file = cli_context.get_app_configuration_file()
+            variables_manager = VariablesManager(app_config_file)
+
+            print()
+            print("=== CLI CONTEXT ===")
+            pprint(cli_context)
+
+            print()
+            print("=== CONFIGURATION ===")
+            pprint(self.cli_configuration)
+
+            print()
+            print("=== ORCHESTRATOR CONFIGURATION ===")
+            pprint(vars(self.cli_configuration.orchestrator))
+
+            print()
+            print("=== VARIABLES ===")
+            pprint(variables_manager.get_all_variables())
+
+        # Expose the commands
+        self.commands = {"debug": debug}

--- a/appcli/commands/debug_cli.py
+++ b/appcli/commands/debug_cli.py
@@ -15,7 +15,6 @@ from appcli.variables_manager import VariablesManager
 # vendor libraries
 import click
 
-
 # local libraries
 from appcli.models.cli_context import CliContext
 from appcli.models.configuration import Configuration

--- a/appcli/commands/encrypt_cli.py
+++ b/appcli/commands/encrypt_cli.py
@@ -54,5 +54,5 @@ class EncryptCli:
             result = cipher.encrypt(text)
             print(result)
 
-        # expose the cli command
+        # expose the CLI command
         self.commands = {"encrypt": encrypt}

--- a/appcli/commands/install_cli.py
+++ b/appcli/commands/install_cli.py
@@ -62,7 +62,7 @@ class InstallCli:
             default=default_install_dir,
         )
         @click.pass_context
-        # NOTE: Hide the cli command as end users should not run it manually
+        # NOTE: Hide the CLI command as end users should not run it manually
         def install(ctx, install_dir: Path):
             logger.info("Generating installer script ...")
 
@@ -106,5 +106,5 @@ class InstallCli:
                     f"Could not generate file from template. The configuration file is likely missing a setting: {e}"
                 )
 
-        # expose the cli command
+        # expose the CLI command
         self.commands = {"install": install}

--- a/appcli/commands/launcher_cli.py
+++ b/appcli/commands/launcher_cli.py
@@ -85,5 +85,5 @@ class LauncherCli:
                     f"Could not generate file from template. The configuration file is likely missing a setting: {e}"
                 )
 
-        # expose the cli command
+        # expose the CLI command
         self.commands = {"launcher": launcher}

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -99,16 +99,17 @@ class MainCli:
             help="Runs a specified oneshot container.",
             context_settings=dict(ignore_unknown_options=True),
         )
-        @click.option(
-            "--force",
-            is_flag=True,
-            help="Force start even if validation checks fail.",
-        )
         @click.argument("service_name", required=True, type=click.STRING)
         @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
         @click.pass_context
-        def oneshot(ctx, force, service_name, extra_args):
+        def oneshot(ctx, service_name, extra_args):
+            logger.info(
+                "Running oneshot service [%s] with args [%s] ...",
+                service_name,
+                extra_args,
+            )
             result = self.orchestrator.oneshot(ctx.obj, service_name, extra_args)
+            logger.info("Oneshot service finished with code [%i]", result.returncode)
             sys.exit(result.returncode)
 
         # expose the cli commands

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -96,20 +96,20 @@ class MainCli:
             self.__shutdown(ctx, force)
 
         @click.command(
-            help="Runs a specified oneshot container.",
+            help="Runs a specified task container.",
             context_settings=dict(ignore_unknown_options=True),
         )
         @click.argument("service_name", required=True, type=click.STRING)
         @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
         @click.pass_context
-        def oneshot(ctx, service_name, extra_args):
+        def task(ctx, service_name, extra_args):
             logger.info(
-                "Running oneshot service [%s] with args [%s] ...",
+                "Running task [%s] with args [%s] ...",
                 service_name,
                 extra_args,
             )
-            result = self.orchestrator.oneshot(ctx.obj, service_name, extra_args)
-            logger.info("Oneshot service finished with code [%i]", result.returncode)
+            result = self.orchestrator.task(ctx.obj, service_name, extra_args)
+            logger.info("Task service finished with code [%i]", result.returncode)
             sys.exit(result.returncode)
 
         # expose the cli commands
@@ -117,7 +117,7 @@ class MainCli:
             "start": start,
             "stop": stop,
             "shutdown": shutdown,
-            "oneshot": oneshot,
+            "task": task,
             "logs": self.orchestrator.get_logs_command(),
         }
 

--- a/appcli/commands/main_cli.py
+++ b/appcli/commands/main_cli.py
@@ -95,11 +95,28 @@ class MainCli:
         def stop(ctx, force):
             self.__shutdown(ctx, force)
 
+        @click.command(
+            help="Runs a specified oneshot container.",
+            context_settings=dict(ignore_unknown_options=True),
+        )
+        @click.option(
+            "--force",
+            is_flag=True,
+            help="Force start even if validation checks fail.",
+        )
+        @click.argument("service_name", required=True, type=click.STRING)
+        @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
+        @click.pass_context
+        def oneshot(ctx, force, service_name, extra_args):
+            result = self.orchestrator.oneshot(ctx.obj, service_name, extra_args)
+            sys.exit(result.returncode)
+
         # expose the cli commands
         self.commands = {
             "start": start,
             "stop": stop,
             "shutdown": shutdown,
+            "oneshot": oneshot,
             "logs": self.orchestrator.get_logs_command(),
         }
 

--- a/appcli/commands/migrate_cli.py
+++ b/appcli/commands/migrate_cli.py
@@ -37,20 +37,21 @@ class MigrateCli:
         self.cli_configuration: Configuration = configuration
 
         @click.command(
-            help="Migrates the application configuration to work with the current application version. Alias of 'upgrade'.",
+            help="Migrates the application configuration to work with the current application version.",
         )
         @click.pass_context
         def migrate(ctx):
             self.__migrate(ctx)
 
         @click.command(
-            help="Upgrades the application configuration to work with the current application version. Alias of 'migrate'.",
+            hidden=True,
+            help="Upgrades the application configuration to work with the current application version.",
         )
         @click.pass_context
         def upgrade(ctx):
             self.__migrate(ctx)
 
-        # expose the cli command
+        # expose the CLI command
         self.commands = {"migrate": migrate, "upgrade": upgrade}
 
     def __migrate(self, ctx):

--- a/appcli/commands/service_cli.py
+++ b/appcli/commands/service_cli.py
@@ -99,9 +99,7 @@ class ServiceCli:
         def shutdown(ctx, force):
             self.__shutdown(ctx, force)
 
-        @service.command(
-            help="Stops all services. Alias to 'shutdown' command.", hidden=True
-        )
+        @service.command(help="Stops all services.", hidden=True)
         @click.option("--force", is_flag=True)
         @click.pass_context
         def stop(ctx, force):
@@ -110,7 +108,7 @@ class ServiceCli:
         # Add the 'logs' subcommand
         service.add_command(self.orchestrator.get_logs_command())
 
-        # expose the cli commands
+        # expose the CLI commands
         self.commands = {
             "service": service,
         }
@@ -132,8 +130,8 @@ class ServiceCli:
         """Ensures the system is in a valid state for startup.
 
         Args:
-            cli_context (CliContext): the current cli context
-            force (bool, optional): If True, only warns on validation failures, rather than exiting
+            cli_context (CliContext): The current CLI context.
+            force (bool, optional): If True, only warns on validation failures, rather than exiting.
         """
         logger.info("Checking system configuration is valid before starting ...")
 
@@ -162,8 +160,8 @@ class ServiceCli:
         """Ensures the system is in a valid state for shutdown.
 
         Args:
-            cli_context (CliContext): the current cli context
-            force (bool, optional): If True, only warns on validation failures, rather than exiting
+            cli_context (CliContext): The current CLI context.
+            force (bool, optional): If True, only warns on validation failures, rather than exiting.
         """
         logger.info("Checking system configuration is valid before shutting down ...")
 

--- a/appcli/commands/task_cli.py
+++ b/appcli/commands/task_cli.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# # -*- coding: utf-8 -*-
+
+"""
+Commands for application tasks.
+________________________________________________________________________________
+
+Created by brightSPARK Labs
+www.brightsparklabs.com
+"""
+
+# standard libraries
+import sys
+
+# vendor libraries
+import click
+
+# local libraries
+from appcli.logger import logger
+from appcli.models.configuration import Configuration
+
+# ------------------------------------------------------------------------------
+# CLASSES
+# ------------------------------------------------------------------------------
+
+
+class TaskCli:
+
+    # --------------------------------------------------------------------------
+    # CONSTRUCTOR
+    # --------------------------------------------------------------------------
+
+    def __init__(self, configuration: Configuration):
+        self.cli_configuration: Configuration = configuration
+        self.orchestrator = configuration.orchestrator
+
+        # ----------------------------------------------------------------------
+        # PUBLIC METHODS
+        # ----------------------------------------------------------------------
+
+        @click.group(
+            invoke_without_command=True,
+            help="Commands for application tasks.",
+        )
+        @click.pass_context
+        def task(ctx):
+            if ctx.invoked_subcommand is not None:
+                # subcommand provided
+                return
+
+            click.echo(ctx.get_help())
+
+        @task.command(
+            help="Runs a specified application task.",
+            context_settings=dict(ignore_unknown_options=True),
+        )
+        @click.argument("service_name", required=True, type=click.STRING)
+        @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
+        @click.pass_context
+        def run(ctx, service_name, extra_args):
+            logger.info(
+                "Running task [%s] with args [%s] ...",
+                service_name,
+                extra_args,
+            )
+            result = self.orchestrator.task(ctx.obj, service_name, extra_args)
+            logger.info("Task service finished with code [%i]", result.returncode)
+            sys.exit(result.returncode)
+
+        # expose the cli commands
+        self.commands = {
+            "task": task,
+        }

--- a/appcli/commands/task_cli.py
+++ b/appcli/commands/task_cli.py
@@ -67,7 +67,7 @@ class TaskCli:
             logger.info("Task service finished with code [%i]", result.returncode)
             sys.exit(result.returncode)
 
-        # expose the cli commands
+        # expose the CLI commands
         self.commands = {
             "task": task,
         }

--- a/appcli/configuration_manager.py
+++ b/appcli/configuration_manager.py
@@ -80,7 +80,7 @@ class ConfigurationManager:
         """Ensures the system is in a valid state for 'configure init'.
 
         Args:
-            cli_context (CliContext): the current cli context
+            cli_context (CliContext): The current CLI context.
         """
         logger.debug("Checking system configuration is valid before initialising ...")
 
@@ -96,8 +96,8 @@ class ConfigurationManager:
         """Applies the current configuration settings to templates to generate application files.
 
         Args:
-            message (str): the message associated with the changes this applies
-            force (bool): If True, only warns on validation failures, rather than exiting
+            message (str): The message associated with the changes this applies.
+            force (bool): If True, only warns on validation failures, rather than exiting.
         """
 
         self.__pre_apply_validation(self.cli_context, force)
@@ -118,8 +118,8 @@ class ConfigurationManager:
         """Ensures the system is in a valid state to do an 'apply' on the configuration
 
         Args:
-            cli_context (CliContext): the current cli context
-            force (bool, optional): If True, only warns on validation failures, rather than exiting
+            cli_context (CliContext): The current CLI context.
+            force (bool, optional): If True, only warns on validation failures, rather than exiting.
         """
         logger.debug("Checking system configuration is valid before 'apply' ...")
 
@@ -263,7 +263,7 @@ class ConfigurationManager:
         """Ensures the system is in a valid state for migration.
 
         Args:
-            cli_context (CliContext): the current cli context
+            cli_context (CliContext): The current CLI context.
         """
         logger.debug("Checking system configuration is valid before migration ...")
 
@@ -678,7 +678,7 @@ def get_generated_configuration_metadata_file(cli_context: CliContext) -> Path:
     """Get the path to the generated configuration's metadata file
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Returns:
         Path: the path to the metadata file
@@ -694,7 +694,7 @@ def confirm_generated_configuration_is_using_current_configuration(
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if metadata file not found, or generated config is out of sync with config.

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -61,7 +61,7 @@ def extract_valid_environment_variable_names(
     and to check that the names are appropriate for bash
 
     Args:
-        ctx (click.Context): current cli context
+        ctx (click.Context): current CLI context
         param (click.Option): the option parameter to validate
         values (click.Tuple): the values passed to the option, could be multiple
     """
@@ -101,7 +101,7 @@ def execute_validation_functions(
     All the 'Must' and 'Should' checks (taking into account 'force') need to succeed in order for this validation to be successful.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
         must_succeed_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run which must not raise any exceptions
             in order for the validation to succeed.
         should_succeed_checks (Iterable[Callable[[click.Context], None]], optional): The check functions to run, which may raise exceptions. If
@@ -153,7 +153,7 @@ def _run_checks(
     """Runs a set of functions which either return None or raises an Exception. Returns all Exception error messages.
 
     Args:
-        cli_context (CliContext): the current context of the cli
+        cli_context (CliContext): the current context of the CLI
         checks (Iterable[Callable[[click.Context], None]]): a set of functions to try running
 
     Returns:

--- a/appcli/git_repositories/git_repositories.py
+++ b/appcli/git_repositories/git_repositories.py
@@ -207,7 +207,7 @@ def confirm_config_dir_exists(cli_context: CliContext):
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the configuration repository does *not* exist.
@@ -223,7 +223,7 @@ def confirm_config_dir_not_exists(cli_context: CliContext):
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the configuration repository exists.
@@ -239,7 +239,7 @@ def confirm_generated_config_dir_exists(cli_context: CliContext):
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the generated configuration repository does not exist.
@@ -255,7 +255,7 @@ def confirm_config_dir_exists_and_is_not_dirty(cli_context: CliContext):
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the configuration repository has been modified and not 'applied'.
@@ -273,7 +273,7 @@ def confirm_generated_config_dir_exists_and_is_not_dirty(cli_context: CliContext
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the generated configuration repository has been manually modified and not checked in.
@@ -293,7 +293,7 @@ def confirm_config_version_matches_app_version(cli_context: CliContext):
     If this fails, it will raise a general Exception with the error message.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
 
     Raises:
         Exception: Raised if the configuration repository version doesn't match the application version.
@@ -314,7 +314,7 @@ def confirm_not_on_master_branch(cli_context: CliContext):
     """Confirm that the configuration repository is not currently on the master branch.
 
     Args:
-        cli_context (CliContext): the current cli context
+        cli_context (CliContext): The current CLI context.
     """
     confirm_config_dir_exists(cli_context)
     config_repo: ConfigurationGitRepository = ConfigurationGitRepository(cli_context)

--- a/appcli/models/cli_context.py
+++ b/appcli/models/cli_context.py
@@ -10,7 +10,7 @@ class CliContext(NamedTuple):
     """ Shared context from a run of the CLI. """
 
     # ---------------------------------
-    # data passed in when cli invoked on the command line
+    # data passed in when CLI invoked on the command line
     # ---------------------------------
 
     configuration_dir: Path
@@ -38,7 +38,7 @@ class CliContext(NamedTuple):
     """ Whether to print debug logs. """
 
     # ---------------------------------
-    # cli build data
+    # CLI build data
     # ---------------------------------
 
     app_name: str

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -250,11 +250,11 @@ class DockerSwarmOrchestrator(Orchestrator):
             docker_compose_override_directory (Path, optional): Path to a directory containing any additional
                 docker-compose override files. Overrides are applied in alphanumeric order of filename. Path is relative
                 to the generated configuration directory.
-            docker_compose_task_file (Path): Path to a docker compose file containing short-lived task containers.
-                Path is relative to the generated configuration directory.
+            docker_compose_task_file (Path): Path to a docker compose file containing services to be run as short-lived
+                tasks. Path is relative to the generated configuration directory.
             docker_compose_task_override_directory (Path): Path to a directory containing any additional
-                docker-compose override files for task containers. Path is relative to the generated configuration
-                directory.
+                docker-compose override files for services used as tasks. Path is relative to the generated
+                configuration directory.
         """
         self.docker_compose_file = docker_compose_file
         self.docker_compose_override_directory = docker_compose_override_directory

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -431,7 +431,7 @@ def decrypt_file(encrypted_file: Path, key_file: Path) -> Path:
         )
         return encrypted_file
 
-    logger.info("Decrypting file [%s] using [%s].", str(encrypted_file), key_file)
+    logger.debug("Decrypting file [%s] using [%s].", str(encrypted_file), key_file)
     decrypted_file: Path = Path(NamedTemporaryFile(delete=False).name)
     crypto.decrypt_values_in_file(encrypted_file, decrypted_file, key_file)
     return decrypted_file

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -44,7 +44,7 @@ class Orchestrator:
         Starts Docker containers.
 
         Args:
-            cli_context (CliContext): The current cli context.
+            cli_context (CliContext): The current CLI context.
             container (str, optional): Name of the container to start. Defaults to all containers.
 
         Returns:
@@ -57,7 +57,7 @@ class Orchestrator:
         Stops all Docker containers.
 
         Args:
-            cli_context (CliContext): The current cli context.
+            cli_context (CliContext): The current CLI context.
 
         Returns:
             CompletedProcess: Result of the orchestrator command.
@@ -72,7 +72,7 @@ class Orchestrator:
         upon completing a short-lived task.
 
         Args:
-            cli_context (CliContext): The current cli context.
+            cli_context (CliContext): The current CLI context.
             service_name (str): Name of the container to run.
             extra_args (Iterable[str]): Extra arguments for running the container
 
@@ -83,10 +83,10 @@ class Orchestrator:
 
     def get_logs_command(self) -> click.Command:
         """
-        Retuns a click command which streams logs for Docker containers.
+        Returns a click command which streams logs for Docker containers.
 
         Args:
-            cli_context (CliContext): The current cli context.
+            cli_context (CliContext): The current CLI context.
 
         Returns:
             click.Command: Command for streaming logs.
@@ -364,7 +364,7 @@ def decrypt_docker_compose_files(
     """Decrypt docker-compose and docker-compose override files.
 
     Args:
-        cli_context (CliContext): The current cli context.
+        cli_context (CliContext): The current CLI context.
         docker_compose_file_relative_path (Path): The relative path to the docker-compose file. Path is relative to the
             generated configuration directory.
         docker_compose_override_directory_relative_path (Path): The relative path to a directory containing
@@ -446,7 +446,7 @@ def execute_compose(
     """Builds and executes a docker-compose command.
 
     Args:
-        cli_context (CliContext): The current cli context.
+        cli_context (CliContext): The current CLI context.
         command (Iterable[str]): The command to execute with docker-compose.
         docker_compose_file_relative_path (Path): The relative path to the docker-compose file. Path is relative to the
             generated configuration directory.

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -199,7 +199,7 @@ class DockerComposeOrchestrator(Orchestrator):
         cli_context: CliContext,
         command: Iterable[str],
     ):
-        return __execute_compose(
+        return execute_compose(
             cli_context,
             command,
             self.docker_compose_file,
@@ -211,7 +211,7 @@ class DockerComposeOrchestrator(Orchestrator):
         cli_context: CliContext,
         command: Iterable[str],
     ):
-        return __execute_compose(
+        return execute_compose(
             cli_context,
             command,
             self.docker_compose_oneshot_file,
@@ -245,7 +245,7 @@ class DockerSwarmOrchestrator(Orchestrator):
 
     def start(self, cli_context: CliContext) -> CompletedProcess:
         subcommand = ["deploy"]
-        compose_files = __decrypt_files(
+        compose_files = decrypt_files(
             cli_context, self.docker_compose_file, self.docker_compose_override_files
         )
         for compose_file in compose_files:
@@ -310,7 +310,7 @@ class DockerSwarmOrchestrator(Orchestrator):
         cli_context: CliContext,
         command: Iterable[str],
     ):
-        return __execute_compose(
+        return execute_compose(
             cli_context,
             command,
             self.docker_compose_oneshot_file,
@@ -322,11 +322,11 @@ class DockerSwarmOrchestrator(Orchestrator):
 
 
 # ------------------------------------------------------------------------------
-# PRIVATE METHODS
+# PUBLIC METHODS
 # ------------------------------------------------------------------------------
 
 
-def __decrypt_files(
+def decrypt_files(
     cli_context: CliContext,
     docker_compose_file: Path,
     docker_compose_override_directory: Path,
@@ -348,12 +348,12 @@ def __decrypt_files(
     # decrypt files if key is available
     key_file = cli_context.get_key_file()
     decrypted_files = [
-        __decrypt_file(encrypted_file, key_file) for encrypted_file in compose_files
+        decrypt_file(encrypted_file, key_file) for encrypted_file in compose_files
     ]
     return decrypted_files
 
 
-def __decrypt_file(encrypted_file: Path, key_file: Path):
+def decrypt_file(encrypted_file: Path, key_file: Path):
     """
     Decrypts the specified file using the supplied key.
 
@@ -376,7 +376,7 @@ def __decrypt_file(encrypted_file: Path, key_file: Path):
     return decrypted_file
 
 
-def __execute_compose(
+def execute_compose(
     cli_context: CliContext,
     command: Iterable[str],
     docker_compose_file: Path,
@@ -402,7 +402,7 @@ def __execute_compose(
         cli_context.get_project_name(),
     ]
 
-    compose_files = __decrypt_files(
+    compose_files = decrypt_files(
         cli_context, docker_compose_file, docker_compose_override_directory
     )
     for compose_file in compose_files:

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -392,8 +392,8 @@ def decrypt_docker_compose_files(
             )
         )
         if os.path.isdir(docker_compose_override_directory):
-            docker_compose_override_files: List[str] = [
-                os.path.join(docker_compose_override_directory, file)
+            docker_compose_override_files: List[Path] = [
+                Path(os.path.join(docker_compose_override_directory, file))
                 for file in os.listdir(docker_compose_override_directory)
                 if os.path.isfile(os.path.join(docker_compose_override_directory, file))
             ]

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -44,7 +44,7 @@ class Orchestrator:
         Starts Docker containers.
 
         Args:
-            cli_context (CliContext): Context for this CLI run.
+            cli_context (CliContext): The current cli context.
             container (str, optional): Name of the container to start. Defaults to all containers.
 
         Returns:
@@ -57,7 +57,7 @@ class Orchestrator:
         Stops all Docker containers.
 
         Args:
-            cli_context (CliContext): Context for this CLI run.
+            cli_context (CliContext): The current cli context.
 
         Returns:
             CompletedProcess: Result of the orchestrator command.
@@ -72,7 +72,7 @@ class Orchestrator:
         upon completing a short-lived task.
 
         Args:
-            cli_context (CliContext): Context for this CLI run.
+            cli_context (CliContext): The current cli context.
             service_name (str): Name of the container to run.
             extra_args (Iterable[str]): Extra arguments to the oneshot command.
 
@@ -86,7 +86,7 @@ class Orchestrator:
         Retuns a click command which streams logs for Docker containers.
 
         Args:
-            cli_context (CliContext): Context for this CLI run.
+            cli_context (CliContext): The current cli context.
 
         Returns:
             click.Command: Command for streaming logs.


### PR DESCRIPTION
Prior to this PR, `appcli` was focused on running a 'service-only' application (docker containers that should run indefinitely when started, e.g. nginx with a web server).
With this PR, we allow `appcli` to be used for both 'services' and for 'tasks', and have made it support 'tasks' as a first-class citizen. It is possible to use `appcli` for 'services' and 'tasks', or either by themselves. resolves #33 

In this context, the services are the docker container services that are expected to run indefinitely when started, and must be halted manually. The tasks are docker container services that are expected to finish by themselves, and allow for 'once-off' applications.

An example service: running nginx.
An example task: running [leodotcloud/swiss-army-knife](https://hub.docker.com/r/leodotcloud/swiss-army-knife) to test host connectivity on port 80.

This PR also addresses the issue where the user couldn't add arbitrary docker-compose override files without needing to modify the python and to rebuild the docker image. resolves #20 