### PR TITLE
Feature/appcli 47 enable modification of settings via editor from a command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     && apt-get update \
     && apt-get -y install \
         git \
+        vim-tiny \
         # docker requirements
         apt-transport-https \
         ca-certificates \

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ usage `./myapp configure [OPTIONS] COMMAND [ARGS]`
 | init     | Initialises the configuration directory.                                |
 | set      | Saves a setting to the configuration.                                   |
 | template | Configures the baseline templates.                                      |
+| edit     | Open the settings file for editing with vim-tiny.                       |
 
 | Option | Description                     |
 | ------ | ------------------------------- |

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -11,6 +11,8 @@ www.brightsparklabs.com
 
 # standard library
 import difflib
+import os
+from subprocess import call
 
 # vendor libraries
 import click
@@ -157,6 +159,18 @@ class ConfigureCli:
             ):
                 # remove superfluous \n characters added by unified_diff
                 print(line.rstrip())
+
+        @configure.command(help="Open the settings file with the set editor")
+        @click.pass_context
+        def edit(ctx):
+            cli_context: CliContext = ctx.obj
+            EDITOR = os.environ.get("EDITOR")
+
+            if EDITOR is None:
+                logger.error("No EDITOR environment variable set")
+                return
+
+            call([EDITOR, cli_context.get_app_configuration_file()])
 
         # Add the 'template' subcommand
         configure.add_command(ConfigureTemplateCli(self.cli_configuration).command)

--- a/appcli/commands/configure_cli.py
+++ b/appcli/commands/configure_cli.py
@@ -11,8 +11,7 @@ www.brightsparklabs.com
 
 # standard library
 import difflib
-import os
-from subprocess import call
+import subprocess
 
 # vendor libraries
 import click
@@ -160,17 +159,13 @@ class ConfigureCli:
                 # remove superfluous \n characters added by unified_diff
                 print(line.rstrip())
 
-        @configure.command(help="Open the settings file with the set editor")
+        @configure.command(help="Open the settings file for editing with vim-tiny.")
         @click.pass_context
         def edit(ctx):
             cli_context: CliContext = ctx.obj
-            EDITOR = os.environ.get("EDITOR")
+            EDITOR = "vim.tiny"
 
-            if EDITOR is None:
-                logger.error("No EDITOR environment variable set")
-                return
-
-            call([EDITOR, cli_context.get_app_configuration_file()])
+            subprocess.run([EDITOR, cli_context.get_app_configuration_file()])
 
         # Add the 'template' subcommand
         configure.add_command(ConfigureTemplateCli(self.cli_configuration).command)

--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -30,6 +30,8 @@ function main()
         --name {{ app_name }}_{{ cli_context.environment }}_launcher_$(date +%s) \
         --rm \
         --interactive \
+        --mount type="bind",source=$(which $EDITOR),target=$(which $EDITOR) \
+        --env "EDITOR"=$(which $EDITOR)\
         $( [[ "${NO_TTY}" != "true" ]] && echo "--tty") \
 {% if cli_context.docker_credentials_file %}
         --volume "{{ cli_context.docker_credentials_file }}:/root/.docker/config.json" \

--- a/appcli/templates/launcher.j2
+++ b/appcli/templates/launcher.j2
@@ -30,8 +30,6 @@ function main()
         --name {{ app_name }}_{{ cli_context.environment }}_launcher_$(date +%s) \
         --rm \
         --interactive \
-        --mount type="bind",source=$(which $EDITOR),target=$(which $EDITOR) \
-        --env "EDITOR"=$(which $EDITOR)\
         $( [[ "${NO_TTY}" != "true" ]] && echo "--tty") \
 {% if cli_context.docker_credentials_file %}
         --volume "{{ cli_context.docker_credentials_file }}:/root/.docker/config.json" \


### PR DESCRIPTION
The first commit stays true to the original issue, being able to use the hosts $EDITOR from inside the container to modify the settings file. 
After discussion with @thomas-anderson-bsl it was decided to install a text editor inside the container (vim-tiny due to its size) and call that from `./myapp configure edit`.