### PR TITLE
APPCLI-57: Add Restart Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ usage: `./myapp service [OPTIONS] COMMAND [ARGS]`
 | logs     | Prints logs from all services.                                                            |
 | shutdown | Shuts down the system. If a service name is provided, shuts down the single service only. |
 | start    | Starts the system. If a service name is provided, starts the single service only.         |
+| restart  | Stops the system, If the --apply flag is provided a configure apply occurs, the system is then restarted. If a service name is provided, restarts the single service only. |
 
 | Option | Description                     |
 | ------ | ------------------------------- |

--- a/README.md
+++ b/README.md
@@ -463,12 +463,12 @@ Runs application services. These are the long-running services which should only
 
 usage: `./myapp service [OPTIONS] COMMAND [ARGS]`
 
-| Command  | Description                                                                               |
-| -------- | ----------------------------------------------------------------------------------------- |
-| logs     | Prints logs from all services.                                                            |
-| shutdown | Shuts down the system. If a service name is provided, shuts down the single service only. |
-| start    | Starts the system. If a service name is provided, starts the single service only.         |
-| restart  | Stops the system, If the --apply flag is provided a configure apply occurs, the system is then restarted. If a service name is provided, restarts the single service only. |
+| Command  | Description                                                                                                                                                                                           |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| logs     | Prints logs from all services.                                                                                                                                                                        |
+| shutdown | Shuts down the system. If a service name is provided, shuts down the single service only.                                                                                                             |
+| start    | Starts the system. If a service name is provided, starts the single service only.                                                                                                                     |
+| restart  | Restarts service(s) (`shutdown` followed by `start`). Optionally run a `configure apply` during the restart with the `--apply` flag. If a service name is provided, restarts the single service only. |
 
 | Option | Description                     |
 | ------ | ------------------------------- |

--- a/appcli/commands/service_cli.py
+++ b/appcli/commands/service_cli.py
@@ -67,7 +67,7 @@ class ServiceCli:
         @click.argument("service_name", required=False, type=click.STRING)
         @click.pass_context
         def restart(ctx, force, apply, service_name):
-            """Restarts services
+            """Restarts service(s)
 
             Args:
                 ctx (Context): Click Context for current CLI.


### PR DESCRIPTION
Added restart command.
If --force or a service name is provided it is passed to subcommands
If --apply is provided a configure apply happens before service is started again
Updated readme

resolves #80 