### PR TITLE
Feature/dis 79 enable install script to upgrade

### DIFF
--- a/appcli/configuration/configuration_dir_state.py
+++ b/appcli/configuration/configuration_dir_state.py
@@ -198,7 +198,6 @@ class UnappliedConfigurationDirState(ConfigurationDirState):
 
         disallowed_command = {
             AppcliCommand.CONFIGURE_INIT: "Cannot initialise an existing configuration.",
-            AppcliCommand.INSTALL: "Cannot install over the top of existing application.",
             AppcliCommand.SERVICE_START: "Cannot start services due to missing generated configuration. Run 'configure apply'.",
             AppcliCommand.SERVICE_SHUTDOWN: "Cannot stop services due to missing generated configuration. Run 'configure apply'.",
             AppcliCommand.SERVICE_LOGS: "Cannot get service logs due to missing generated configuration. Run 'configure apply'.",
@@ -217,7 +216,6 @@ class CleanConfigurationDirState(ConfigurationDirState):
     def __init__(self) -> None:
         disallowed_command = {
             AppcliCommand.CONFIGURE_INIT: "Cannot initialise an existing configuration.",
-            AppcliCommand.INSTALL: "Cannot install over the top of existing application.",
         }
         disallowed_command_unless_forced = {}
 
@@ -231,7 +229,6 @@ class DirtyConfConfigurationDirState(ConfigurationDirState):
 
         disallowed_command = {
             AppcliCommand.CONFIGURE_INIT: "Cannot initialise an existing configuration.",
-            AppcliCommand.INSTALL: "Cannot install over the top of existing application.",
             AppcliCommand.MIGRATE: "Cannot migrate with a dirty configuration. Run 'configure apply'.",
         }
         disallowed_command_unless_forced = {
@@ -250,7 +247,6 @@ class DirtyGenConfigurationDirState(ConfigurationDirState):
 
         disallowed_command = {
             AppcliCommand.CONFIGURE_INIT: "Cannot initialise an existing configuration.",
-            AppcliCommand.INSTALL: "Cannot install over the top of existing application.",
             AppcliCommand.MIGRATE: "Cannot migrate with a dirty generated configuration. Run 'configure apply'.",
         }
         disallowed_command_unless_forced = {
@@ -270,7 +266,6 @@ class DirtyConfAndGenConfigurationDirState(ConfigurationDirState):
 
         disallowed_command = {
             AppcliCommand.CONFIGURE_INIT: "Cannot initialise an existing configuration.",
-            AppcliCommand.INSTALL: "Cannot install over the top of existing application.",
             AppcliCommand.MIGRATE: "Cannot migrate with a dirty generated configuration. Run 'configure apply'.",
         }
         disallowed_command_unless_forced = {

--- a/appcli/configuration_manager.py
+++ b/appcli/configuration_manager.py
@@ -235,7 +235,7 @@ class ConfigurationManager:
         """Seed the raw configuration into the configuration directory"""
         print_header("Seeding configuration directory ...")
 
-        logger.info("Copying app configuration file ...")
+        logger.debug("Copying app configuration file ...")
         seed_app_configuration_file = self.cli_configuration.seed_app_configuration_file
         if not seed_app_configuration_file.is_file():
             error_and_exit(
@@ -259,7 +259,7 @@ class ConfigurationManager:
             shutil.copy2(stack_configuration_file, target_stack_configuration_file)
 
         # Create the configurable templates directory
-        logger.info("Copying configurable templates ...")
+        logger.debug("Copying configurable templates ...")
         configurable_templates_dir = self.cli_context.get_configurable_templates_dir()
         configurable_templates_dir.mkdir(parents=True, exist_ok=True)
         seed_configurable_templates_dir = (
@@ -277,7 +277,7 @@ class ConfigurationManager:
 
         # Copy each seed file to the configurable templates directory
         for source_file in seed_configurable_templates_dir.glob("**/*"):
-            logger.info(source_file)
+            logger.debug(source_file)
             relative_file = source_file.relative_to(seed_configurable_templates_dir)
             target_file = configurable_templates_dir.joinpath(relative_file)
 
@@ -358,14 +358,14 @@ class ConfigurationManager:
             if template_file.suffix == ".j2":
                 # parse jinja2 templates against configuration
                 target_file = target_file.with_suffix("")
-                logger.info("Generating configuration file [%s] ...", target_file)
+                logger.debug("Generating configuration file [%s] ...", target_file)
                 self.__generate_from_template(
                     template_file,
                     target_file,
                     self.__get_variables_manager().get_all_variables(),
                 )
             else:
-                logger.info("Copying configuration file to [%s] ...", target_file)
+                logger.debug("Copying configuration file to [%s] ...", target_file)
                 shutil.copy2(template_file, target_file)
 
     def __directory_is_not_empty(self, directory: Path) -> bool:
@@ -557,7 +557,7 @@ class ConfigurationManager:
             )
 
             # Create the backup
-            logger.info(f"Backing up directory [{source_dir}] to [{output_filename}]")
+            logger.debug(f"Backing up directory [{source_dir}] to [{output_filename}]")
             with tarfile.open(output_filename, "w:gz") as tar:
                 tar.add(source_dir, arcname=os.path.basename(source_dir))
 
@@ -569,13 +569,13 @@ class ConfigurationManager:
 
             # Remove the existing directory
             shutil.rmtree(source_dir, ignore_errors=True)
-            logger.info(
+            logger.debug(
                 f"Deleted previous generated configuration directory [{source_dir}]"
             )
 
         source_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Created clean directory [{source_dir}]")
+        logger.debug(f"Created clean directory [{source_dir}]")
 
         return source_dir
 

--- a/appcli/functions.py
+++ b/appcli/functions.py
@@ -67,7 +67,7 @@ def encrypt_text(cli_context, text: str):
 
     key_file: Path = cli_context.get_key_file()
     if not key_file.is_file():
-        logger.info("Creating encryption key at [%s]", key_file)
+        logger.debug("Creating encryption key at [%s]", key_file)
         crypto.create_and_save_key(key_file)
 
     cipher = Cipher(key_file)

--- a/appcli/keycloak_manager.py
+++ b/appcli/keycloak_manager.py
@@ -211,7 +211,7 @@ class KeycloakManager:
 
         """
         self.create_realm(app_name)
-        logger.info(f"Created realm [{app_name}]")
+        logger.debug(f"Created realm [{app_name}]")
 
         client_payload = {
             "redirectUris": ["*"],
@@ -231,19 +231,19 @@ class KeycloakManager:
         }
         self.create_client(app_name, app_name, client_payload)
         secret = self.get_client_secret(app_name, app_name)
-        logger.info(f"Created client [{app_name}] with secret [{secret}]")
+        logger.debug(f"Created client [{app_name}] with secret [{secret}]")
 
         realm_role = f"{app_name}-admin"
         self.create_realm_role(app_name, realm_role)
-        logger.info(f"Created realm role [{realm_role}]")
+        logger.debug(f"Created realm role [{realm_role}]")
 
         username = "test.user"
         self.create_user(
             app_name, username, "password", "Test", "User", "test.user@email.test"
         )
-        logger.info(
+        logger.debug(
             f"Created user [test.user] with password [password] in realm [{app_name}]"
         )
 
         self.assign_realm_role(app_name, username, realm_role)
-        logger.info(f"Assigned realm role [{realm_role}] to user [test.user]")
+        logger.debug(f"Assigned realm role [{realm_role}] to user [test.user]")

--- a/appcli/templates/installer.j2
+++ b/appcli/templates/installer.j2
@@ -17,19 +17,26 @@ function main()
 
     cd "{{ install_dir }}"
 
+    # Create versioned launcher
     local _launcher_versioned=".{{ cli_context.app_name|lower }}-{{ cli_context.app_version }}"
     generate_launcher > "${_launcher_versioned}" || print_error_and_exit "No permissions to write to [${_launcher_versioned}]"
     chmod a+x "${_launcher_versioned}"
 
+    # Create date-based launcher link
     local _launcher_deploy_date=".$(date -Isec --utc)"
     rm -f "${_launcher_deploy_date}" || print_error_and_exit "No permissions to delete to [${_launcher_deploy_date}]"
     ln -s "${_launcher_versioned}" "${_launcher_deploy_date}"
 
     local _launcher_generic="{{ cli_context.app_name|lower }}"
+
+    # If the generic launcher already exists, upgrade the existing application
+    [[ -e "${_launcher_generic}" ]] && upgrade_existing_application "${_launcher_generic}" "${_launcher_versioned}"
+
+    # Update the symlink to the generic launcher
     rm -f "${_launcher_generic}" || print_error_and_exit "No permissions to delete to [${_launcher_generic}]"
     ln -s "${_launcher_versioned}" "${_launcher_generic}"
 
-    cat <<EOF
+    >&2 cat <<EOF
     $(date -Isec --utc) INFO: {{ cli_context.app_name|lower }} version [{{ cli_context.app_version }}] can be launched via:
 
         {{ install_dir }}/{{ cli_context.app_name|lower }}
@@ -61,9 +68,25 @@ function generate_launcher()
             launcher
 }
 
+function upgrade_existing_application()
+{
+    local _launcher_existing="$(realpath ${1})"
+    local _launcher_upgrade="$(realpath ${2})"
+
+    >&2 echo "Installing an upgrade on existing application..."
+
+    # Stop services and apply with the old launcher
+    NO_TTY=true ${_launcher_existing} service stop
+    NO_TTY=true ${_launcher_existing} configure apply --force
+
+    # Migrate and apply with the new launcher
+    NO_TTY=true ${_launcher_upgrade} migrate
+    NO_TTY=true ${_launcher_upgrade} configure apply --force
+}
+
 function print_error_and_exit()
 {
-    echo "$(date -Isec --utc) ERROR: $@"
+    >&2 echo "$(date -Isec --utc) ERROR: $@"
     exit 1
 }
 

--- a/appcli/variables_manager.py
+++ b/appcli/variables_manager.py
@@ -110,6 +110,6 @@ class VariablesManager:
             variables (Dict): the variables to save
         """
         full_path = self.configuration_file.absolute().as_posix()
-        logger.info(f"Saving configuration to [{full_path}] ...")
+        logger.debug(f"Saving configuration to [{full_path}] ...")
         with open(full_path, "w") as config_file:
             self.yaml.dump(variables, config_file)

--- a/tests/test_configuration_state.py
+++ b/tests/test_configuration_state.py
@@ -48,8 +48,8 @@ def test_no_state():
         assert pytest_wrapped_e.value.code == 1
 
 
-def test_no_configure_init_or_install_on_existing_repos():
-    """When the configuration dir exists, do not allow 'configure init' or 'install'."""
+def test_no_configure_init_on_existing_repos():
+    """When the configuration dir exists, do not allow 'configure init'."""
 
     for state_class in [
         UnappliedConfigurationDirState,
@@ -60,12 +60,11 @@ def test_no_configure_init_or_install_on_existing_repos():
     ]:
         state: ConfigurationDirState = state_class()
 
-        for command in [AppcliCommand.CONFIGURE_INIT, AppcliCommand.INSTALL]:
-            with pytest.raises(SystemExit) as pytest_wrapped_e:
-                # Expect that we cannot initialise on an already-initialised repo
-                state.verify_command_allowed(command)
-            assert pytest_wrapped_e.type == SystemExit
-            assert pytest_wrapped_e.value.code == 1
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            # Expect that we cannot initialise on an already-initialised repo
+            state.verify_command_allowed(AppcliCommand.CONFIGURE_INIT)
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
 
 
 # TODO: More ConfigurationDirStateFactory tests


### PR DESCRIPTION
This PR enables the `install` script to perform the necessary steps to perform an 'upgrade' if it detects an existing application.
Essentially the 'install' script is now a 'install and upgrade' script.

I've also lowered the verbosity of a fair number of log messages, since it wasn't necessary to keep them as INFO level - it was just clogging up the output shown to the user by default.

We also allow the `install` command to be run at any conf state. This is because the `install` command only prints out the templated file, so running the command isn't dangerous by itself, and is only preventing us from looking at the script.