### PR TITLE
TERA-496: Remove unnecessary docker installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,28 +20,9 @@ RUN \
     && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90appcli \
     # prepare for docker install
     && apt-get update \
-    && apt-get -y install \
+    && apt-get -y install --no-install-recommends \
         git \
         vim-tiny \
-        # docker requirements
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg2 \
-        software-properties-common \
-    # install docker
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-    && add-apt-repository \
-        "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get -y install docker-ce docker-ce-cli containerd.io \
-    # cleanup to reduce image size
-    && apt-get -y remove \
-        apt-transport-https \
-        ca-certificates \
-        curl \
-        gnupg2 \
-        software-properties-common \
     && apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/appcli/orchestrators.py
+++ b/appcli/orchestrators.py
@@ -247,6 +247,8 @@ class DockerComposeOrchestrator(Orchestrator):
         )
 
 
+# This is now broken since the Docker image no longer includes a Docker installation.
+# TODO: (GH-115) Replace calls to docker with the `docker` python library which only requires access to the docker.sock
 class DockerSwarmOrchestrator(Orchestrator):
     """
     Uses Docker Swarm to orchestrate containers.
@@ -342,6 +344,8 @@ class DockerSwarmOrchestrator(Orchestrator):
             cli_context.get_configuration_dir_state().verify_command_allowed(
                 AppcliCommand.SERVICE_LOGS
             )
+            # This is now broken since the Docker image no longer includes a Docker installation.
+            # TODO: (GH-115) Replace this call with using the `docker` python library which only requires access to the docker.sock
             command = ["docker", "service", "logs", "--follow"]
             command.append(f"{cli_context.get_project_name()}_{service}")
             result = self.__exec_command(command)
@@ -370,6 +374,8 @@ class DockerSwarmOrchestrator(Orchestrator):
     def __docker_stack(
         self, cli_context: CliContext, subcommand: Iterable[str]
     ) -> CompletedProcess:
+        # This is now broken since the Docker image no longer includes a Docker installation.
+        # TODO: (GH-115) Replace this call with using the `docker` python library which only requires access to the docker.sock
         command = ["docker", "stack"]
         command.extend(subcommand)
         command.append(cli_context.get_project_name())


### PR DESCRIPTION
Having `docker` installed in the `brightsparklabs/appcli` image isn't strictly necessary.

For the `DockerComposeOrchestrator`, we only call `docker-compose` commands, which talks directly to the `/var/run/docker.sock`. Since this is always mounted in from the launcher script, this isn't a problem.

*BREAKING CHANGE*
For the `DockerSwarmOrchestrator`, we do call `docker` commands directly. This means removing the docker installation from the image breaks this orchestrator.
We can replace calls an installed `docker` with the `docker` python library. https://github.com/docker/docker-py

The following successfully executes:
```
docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/bash python:3.8.2-slim-buster
$ pip install docker
$ python
$$ import docker
$$ client = docker.from_env()
$$ client.containers.run("hello-world")
```