### PR TITLE
Feature/GH-118-add-version-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ### Added
 
-- [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli 
+- [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ## [Unreleased]
 
+### Added
+
+- [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli 
+
 ---
 
 ## [1.3.4] - (14/05/2021)

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ To be used in conjunction with your application `./myapp <command>` e.g. `./myap
 | restore      | Restore a backup of application data and configuration.           |
 | service      | Lifecycle management commands for application services.           |
 | task         | Commands for application tasks.                                   |
-| version      | Fetches the version of the app being managed with appcli          |
+| version      | Fetches the version of the app being managed with appcli.         |
 | view-backups | View a list of locally-available backups.                         |
 
 ### Options
@@ -540,7 +540,7 @@ usage: `./myapp task [OPTIONS] COMMAND [ARGS]`
 
 #### Command: `version`
 
-Fetches the version of the app being managed with appcli
+Fetches the version of the app being managed with appcli.
 
 usage: `./myapp version`
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ To be used in conjunction with your application `./myapp <command>` e.g. `./myap
 | restore      | Restore a backup of application data and configuration.           |
 | service      | Lifecycle management commands for application services.           |
 | task         | Commands for application tasks.                                   |
+| version      | Fetches the version of the app being managed with appcli          |
 | view-backups | View a list of locally-available backups.                         |
 
 ### Options
@@ -536,6 +537,12 @@ usage: `./myapp task [OPTIONS] COMMAND [ARGS]`
 | Option | Description                     |
 | ------ | ------------------------------- |
 | --help | Show the help message and exit. |
+
+#### Command: `version`
+
+Fetches the version of the app being managed with appcli
+
+usage: `./myapp version`
 
 #### Command: `view-backups`
 

--- a/appcli/cli_builder.py
+++ b/appcli/cli_builder.py
@@ -30,6 +30,7 @@ from appcli.commands.launcher_cli import LauncherCli
 from appcli.commands.migrate_cli import MigrateCli
 from appcli.commands.service_cli import ServiceCli
 from appcli.commands.task_cli import TaskCli
+from appcli.commands.version_cli import VersionCli
 from appcli.functions import error_and_exit, extract_valid_environment_variable_names
 from appcli.logger import enable_debug_logging, logger
 from appcli.models.cli_context import CliContext
@@ -72,6 +73,7 @@ def create_cli(configuration: Configuration, desired_environment: Dict[str, str]
         ServiceCli,
         TaskCli,
         BackupManagerCli,
+        VersionCli,
     ):
         commands = cli_class(configuration).commands
         default_commands.update(**commands)

--- a/appcli/commands/version_cli.py
+++ b/appcli/commands/version_cli.py
@@ -11,11 +11,11 @@ Created by brightSPARK Labs
 www.brightsparklabs.com
 """
 
-# standard libraries
-import os
-
 # vendor libraries
 import click
+
+# standard libraries
+from appcli.models.cli_context import CliContext
 
 # local libraries
 from appcli.models.configuration import Configuration
@@ -36,9 +36,11 @@ class VersionCli:
         self.configuration: Configuration = configuration
 
         @click.command(help="Fetches app version")
-        def version():
+        @click.pass_context
+        def version(ctx):
             """Fetches the version of the app being managed with appcli"""
-            print(os.environ.get("APP_VERSION", "latest"))
+            cli_context: CliContext = ctx.obj
+            print(cli_context.app_version)
 
         # expose the CLI command
         self.commands = {"version": version}

--- a/appcli/commands/version_cli.py
+++ b/appcli/commands/version_cli.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# # -*- coding: utf-8 -*-
+
+"""
+The version command available when running the CLI.
+
+Responsible for returning app version.
+________________________________________________________________________________
+
+Created by brightSPARK Labs
+www.brightsparklabs.com
+"""
+
+# vendor libraries
+import click
+import os
+
+# local libraries
+from appcli.commands.appcli_command import AppcliCommand
+from appcli.models.cli_context import CliContext
+from appcli.models.configuration import Configuration
+
+# ------------------------------------------------------------------------------
+# CLASSES
+# ------------------------------------------------------------------------------
+
+
+class VersionCli:
+
+    # --------------------------------------------------------------------------
+    # CONSTRUCTOR
+    # --------------------------------------------------------------------------
+
+    def __init__(self, configuration: Configuration):
+
+        self.configuration: Configuration = configuration
+
+        @click.command(help="Returns app version")
+        def version():
+            """Outputs the version of the app being managed with appcli
+            """
+            print(os.environ.get("APP_VERSION", "latest"))
+
+        # expose the CLI command
+        self.commands = {"version": version}

--- a/appcli/commands/version_cli.py
+++ b/appcli/commands/version_cli.py
@@ -4,7 +4,7 @@
 """
 The version command available when running the CLI.
 
-Responsible for returning app version.
+Responsible for fetching current app version.
 ________________________________________________________________________________
 
 Created by brightSPARK Labs
@@ -35,9 +35,9 @@ class VersionCli:
 
         self.configuration: Configuration = configuration
 
-        @click.command(help="Returns app version")
+        @click.command(help="Fetches app version")
         def version():
-            """Outputs the version of the app being managed with appcli
+            """Fetches the version of the app being managed with appcli
             """
             print(os.environ.get("APP_VERSION", "latest"))
 

--- a/appcli/commands/version_cli.py
+++ b/appcli/commands/version_cli.py
@@ -11,13 +11,13 @@ Created by brightSPARK Labs
 www.brightsparklabs.com
 """
 
-# vendor libraries
-import click
+# standard libraries
 import os
 
+# vendor libraries
+import click
+
 # local libraries
-from appcli.commands.appcli_command import AppcliCommand
-from appcli.models.cli_context import CliContext
 from appcli.models.configuration import Configuration
 
 # ------------------------------------------------------------------------------
@@ -37,8 +37,7 @@ class VersionCli:
 
         @click.command(help="Fetches app version")
         def version():
-            """Fetches the version of the app being managed with appcli
-            """
+            """Fetches the version of the app being managed with appcli"""
             print(os.environ.get("APP_VERSION", "latest"))
 
         # expose the CLI command

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,7 +2,7 @@
 # # -*- coding: utf-8 -*-
 
 """
-Unit tests for version command.
+Unit tests for `version` command.
 ________________________________________________________________________________
 
 Created by brightSPARK Labs
@@ -10,16 +10,36 @@ www.brightsparklabs.com
 """
 
 # vendor libraries
-import pytest
 from click.testing import CliRunner
 
 # local libraries
 from appcli.commands.version_cli import VersionCli
+from appcli.models.cli_context import CliContext
 
 
 def test_version_cli():
-    with pytest.raises(SystemExit) as exit_code:
-        runner = CliRunner()
-        result = runner.invoke(VersionCli(None).commands["version"]())
-        assert exit_code.value.code == 0
-        assert result.output == "latest\n"
+
+    # Unfortunately, there's no easy way to get access to the main cli command,
+    # so we have to test the version command directly. This requires initialising
+    # the CliContext into the desired state, including setting the `app_version`.
+    # Therefore this unit test doesn't deal with ensuring the `app_version` is
+    # correctly populated from within the create_cli function.
+    version = "1.2.3"
+    cli_context = CliContext(
+        configuration_dir=None,
+        data_dir=None,
+        additional_data_dirs=None,
+        backup_dir=None,
+        additional_env_variables=None,
+        environment="test",
+        docker_credentials_file=None,
+        subcommand_args=None,
+        debug=True,
+        app_name="APP_NAME",
+        app_version=f"{version}",
+        commands=None,
+    )
+    runner = CliRunner()
+    result = runner.invoke(VersionCli(None).commands["version"], obj=cli_context)
+    assert result.exit_code == 0
+    assert result.output == f"{version}\n"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# # -*- coding: utf-8 -*-
+
+"""
+Unit tests for version command.
+________________________________________________________________________________
+
+Created by brightSPARK Labs
+www.brightsparklabs.com
+"""
+
+# vendor libraries
+import pytest
+from click.testing import CliRunner
+
+# local libraries
+from appcli.commands.version_cli import VersionCli
+
+
+def test_version_cli():
+    with pytest.raises(SystemExit) as exit_code:
+        runner = CliRunner()
+        result = runner.invoke(VersionCli(None).commands["version"]())
+        assert exit_code.value.code == 0
+        assert result.output == "latest\n"


### PR DESCRIPTION
New command 'version' added, which fetches the version of the app being managed with appcli
usage: `appcli version`

resolves #118 