### PR TITLE
APPCLI-74: Renamed launcher script hidden file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ### Added
 
+- Renaming the launcher script to create only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`
 - [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 - [#144](https://github.com/brightsparklabs/appcli/issues/144) Added `--lines/-n` option to the `logs` commands for orchestrators. This is the `n` number of lines from the end to start the tail.
 - [#147](https://github.com/brightsparklabs/appcli/issues/147) Remove ':' character from backup filenames, to allow tools like `tar` to work more easily with the unmodified filename.

--- a/appcli/templates/installer.j2
+++ b/appcli/templates/installer.j2
@@ -18,14 +18,9 @@ function main()
     cd "{{ install_dir }}"
 
     # Create versioned launcher
-    local _launcher_versioned=".{{ cli_context.app_name|lower }}-{{ cli_context.app_version }}"
+    local _launcher_versioned=".$(date -Isec --utc)_{{ cli_context.app_name|lower }}_{{ cli_context.app_version }}"
     generate_launcher > "${_launcher_versioned}" || print_error_and_exit "No permissions to write to [${_launcher_versioned}]"
     chmod a+x "${_launcher_versioned}"
-
-    # Create date-based launcher link
-    local _launcher_deploy_date=".$(date -Isec --utc)"
-    rm -f "${_launcher_deploy_date}" || print_error_and_exit "No permissions to delete to [${_launcher_deploy_date}]"
-    ln -s "${_launcher_versioned}" "${_launcher_deploy_date}"
 
     local _launcher_generic="{{ cli_context.app_name|lower }}"
 


### PR DESCRIPTION
The installer script generator has been modified to generate only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`
This has been tested with both `--install-dir` and `--configuration-dir`