### PR TITLE
APPCLI-77: Run hadolint linter over Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ### Added
 
+- Ran hadolint linter over Dockerfile.
 - Renaming the launcher script to create only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`.
 - [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 - [#144](https://github.com/brightsparklabs/appcli/issues/144) Added `--lines/-n` option to the `logs` commands for orchestrators. This is the `n` number of lines from the end to start the tail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ### Added
 
-- Ran hadolint linter over Dockerfile.
 - Renaming the launcher script to create only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`.
 - [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 - [#144](https://github.com/brightsparklabs/appcli/issues/144) Added `--lines/-n` option to the `logs` commands for orchestrators. This is the `n` number of lines from the end to start the tail.
@@ -22,6 +21,7 @@ The changelog is applicable from version `1.0.0` onwards.
 ### Fixed
 
 - Fixed issue where applications with non-shell-safe `app_name` weren't able to be installed or run.
+- Fix Dockerfile issues identified by [Hadolint](https://github.com/hadolint/hadolint).
 - Minor fix to README example python script.
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@
  # www.brightsparklabs.com
  ##
 
-FROM alpine AS docker-binary-download
+FROM alpine:3.15.0 AS docker-binary-download
 
 WORKDIR /tmp
 
 # Download and extract the static docker binary
 RUN \
-    wget https://download.docker.com/linux/static/stable/x86_64/docker-20.10.6.tgz \
+    wget -q https://download.docker.com/linux/static/stable/x86_64/docker-20.10.6.tgz \
     && tar xf docker-20.10.6.tgz
 
 FROM python:3.8.2-slim-buster
@@ -32,8 +32,8 @@ RUN \
     # prepare for docker install
     && apt-get update \
     && apt-get -y install --no-install-recommends \
-        git \
-        vim-tiny \
+        git=2.25.1 \
+        vim-tiny=8.1.2269 \
     && apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN \
     # prepare for docker install
     && apt-get update \
     && apt-get -y install --no-install-recommends \
-        git=2.25.1 \
-        vim-tiny=8.1.2269 \
+        git=1:2.20.1-2+deb10u3 \
+        vim-tiny=2:8.1.0875-5 \
     && apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The hadolint linter detected 3 issues:

1. alpine base image needed a version number.
2. wget should be run with -q/--quiet option from this context.
3. Both git and vim-tiny packages needed version numbers.

All of these issues have been fixed.