### PR TITLE
Feature/appcli 96 remove changelog enforcement for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
   open-pull-requests-limit: 20
   reviewers:
   - thomas-anderson-bsl
+  - benjamin-wiffen
   labels:
   - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: pip
   directory: /
   schedule:
-    # Defaults to Monday 5am UTC.
-    interval: weekly
+    # Defaults to the first of the month.
+    interval: monthly
   open-pull-requests-limit: 20
   reviewers:
   - thomas-anderson-bsl

--- a/.github/workflows/changelog_enforcer.yml
+++ b/.github/workflows/changelog_enforcer.yml
@@ -10,7 +10,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !(github.actor == "dependabot[bot]") }}
+    if: ${{ !(github.actor == 'dependabot[bot]') }}
     steps:
       - uses: actions/checkout@v3
       - uses: dangoslen/changelog-enforcer@v2

--- a/.github/workflows/changelog_enforcer.yml
+++ b/.github/workflows/changelog_enforcer.yml
@@ -10,6 +10,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
     runs-on: ubuntu-latest
+    if: ${{ !(github.actor == "dependabot[bot]") }}
     steps:
       - uses: actions/checkout@v3
       - uses: dangoslen/changelog-enforcer@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ### Added
 
+- Disable `CHANGELOG.md` github action enforcement for `dependabot`.
 - Run hadolint on every commit with the use of [pre-commit](https://pre-commit.com/).
 - Add a CI pipeline check to lint the `Dockerfile` using [Hadolint](https://github.com/hadolint/hadolint).
 - [#239](https://github.com/brightsparklabs/appcli/issues/239) Support application context files, which enables application-specific Jinja2 templating contexts.
@@ -42,7 +43,7 @@ The changelog is applicable from version `1.0.0` onwards.
 
 - Enable custom commands to run `exec` commands on service containers via the orchestrator
 - Allow tasks to be run in detached mode with flag `-d/--detach`.
->>>>>>> origin/develop
+  > > > > > > > origin/develop
 - Renaming the launcher script to create only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`.
 - [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 - [#144](https://github.com/brightsparklabs/appcli/issues/144) Added `--lines/-n` option to the `logs` commands for orchestrators. This is the `n` number of lines from the end to start the tail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ The changelog is applicable from version `1.0.0` onwards.
 
 - Enable custom commands to run `exec` commands on service containers via the orchestrator
 - Allow tasks to be run in detached mode with flag `-d/--detach`.
-  > > > > > > > origin/develop
 - Renaming the launcher script to create only 1 hidden file: `.<timestamp>_<app_name>_<app_version>`.
 - [#118](https://github.com/brightsparklabs/appcli/issues/118) Added `version` command to fetch version of app managed by appcli.
 - [#144](https://github.com/brightsparklabs/appcli/issues/144) Added `--lines/-n` option to the `logs` commands for orchestrators. This is the `n` number of lines from the end to start the tail.


### PR DESCRIPTION
This has been tested with `nektos/act` and it appears to work fine.
The dependabot username that was tested was `dependabot[bot]` as this was what was referenced at https://docs.github.com/en/enterprise-server@3.3/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions