### PR TITLE
Feature/appcli 97 update quick start guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The changelog is applicable from version `1.0.0` onwards.
 ### Fixed
 
 - On tag commits, Docker images and python wheels should now be correctly published.
+- Update the list of commands used in the `quickstart.md` guide to appropriately reflect the required steps and functionality needed to get a sample appcli application running.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ The changelog is applicable from version `1.0.0` onwards.
 ### Fixed
 
 - On tag commits, Docker images and python wheels should now be correctly published.
-- Update the list of commands used in the `quickstart.md` guide to appropriately reflect the required steps and functionality needed to get a sample appcli application running.
+- Update the list of commands used in the `quickstart.md` guide to appropriately reflect the required functionality needed to get a sample appcli application running.
+- Minor updates to styling in `README.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ internal classes and methods is now by a full path, rather than being exposed
 at the root. This was done to allow access to all methods and classes using
 python3 implicit namespaced packages.
 
+```python
     # filename: myapp.py
 
     #!/usr/bin/env python3
@@ -94,7 +95,7 @@ python3 implicit namespaced packages.
             baseline_templates_dir=BASE_DIR / 'resources/templates/baseline',
             configurable_templates_dir=BASE_DIR / 'resources/templates/configurable',
             orchestrator=DockerComposeOrchestrator(
-                # NOTE: These paths are relative to `resources/templates/baseline`.
+                # NOTE: These paths are relative to 'resources/templates/baseline'.
                 docker_compose_file = Path('docker-compose.yml'),
                 docker_compose_override_directory = Path('docker-compose.override.d/'),
                 docker_compose_task_file = Path('docker-compose.tasks.yml'),
@@ -112,7 +113,7 @@ python3 implicit namespaced packages.
 
     if __name__ == '__main__':
         main()
-
+```
 #### Custom Commands
 
 You can specify some custom top-level commands by adding click commands or command groups to the configuration object.

--- a/quickstart.md
+++ b/quickstart.md
@@ -94,7 +94,7 @@ RUN pip install --requirement requirements.txt
 COPY src .
 
 ARG APP_VERSION=latest
-ENV APP_VERSION=${APP_VERSION}
+ENV APP_VERSION=\${APP_VERSION}
 
 EOF
 ```

--- a/quickstart.md
+++ b/quickstart.md
@@ -23,10 +23,10 @@ touch src/resources/stack-settings.yml
 #### Create the appcli application
 
 ```bash
-touch src/resources/myapp.py
-chmod +x src/resources/myapp.py
+touch src/myapp.py
+chmod +x src/myapp.py
 
-cat <<EOF >src/resources/myapp.py
+cat <<EOF >src/myapp.py
 #!/usr/bin/env python3
 # # -*- coding: utf-8 -*-
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -16,8 +16,8 @@ Run the following commands to create the required files and folders
 
 ```bash
 mkdir -p src/resources/templates/{baseline,configurable}
-touch src/resources/settings.py
-touch src/resources/stack-settings.py
+touch src/resources/settings.yml
+touch src/resources/stack-settings.yml
 ```
 
 #### Create the appcli application
@@ -60,7 +60,7 @@ def main():
         baseline_templates_dir=BASE_DIR / 'resources/templates/baseline',
         configurable_templates_dir=BASE_DIR / 'resources/templates/configurable',
         orchestrator=DockerComposeOrchestrator(
-            # NOTE: These paths are relative to `resources/templates/baseline`.
+            # NOTE: These paths are relative to 'resources/templates/baseline'.
             docker_compose_file = Path('docker-compose.yml')
         ),
     )

--- a/quickstart.md
+++ b/quickstart.md
@@ -160,7 +160,7 @@ docker run --rm brightsparklabs/myapp:latest install
 Once you can successfully see the script printed on the command line, you are ready to install
 
 ```bash
-docker run --rm brightsparklabs/myapp:latest install | sudo bash`
+docker run --rm brightsparklabs/myapp:latest install | sudo bash
 ```
 
 ### Initialise
@@ -169,7 +169,7 @@ Once you have successfully ran the install script you can initialise the app by 
 following command:
 
 ```bash
-/opt/brightsparklabs/myapp/production/myapp configure init`
+/opt/brightsparklabs/myapp/production/myapp configure init
 ```
 
 ### Applying the settings

--- a/quickstart.md
+++ b/quickstart.md
@@ -146,7 +146,7 @@ Before we build our application please make sure your directory reflects the fol
 ### Build the container
 
 ```
-docker build -t brightsparklabs/myapp --build-arg APP_VERSION=latest .
+docker build -t brightsparklabs/myapp:latest --build-arg APP_VERSION=latest .
 ```
 
 ### Run the installed script.

--- a/quickstart.md
+++ b/quickstart.md
@@ -110,13 +110,15 @@ echo "bsl-appcli==${APPCLI_VERSION}" >> requirements.txt
 
 ### Create  docker-compose.yml
 
-```
+```bash
 cat <<EOF >src/resources/templates/baseline/docker-compose.yml
 
 version: '3'
 services:
   echo-server:
     image: ealen/echo-server:0.5.1
+
+EOF
 ```
 
 The above uses [Echo-Server](https://ealenn.github.io/Echo-Server/pages/quick-start/docker.html#run)


### PR DESCRIPTION
These changes should ensure that the quick start guide now appropriately reflects the steps required to get a basic application running with appcli. I have also added a minor styling update to the README relating to displaying the example code for myapp.py as python code. This styling is used in other places in the README for python code so I thought it would be best to use it there as well. 