### PR TITLE
APPCLI-113: Add Git repository ownership fix to AppCli Docker file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changelog is applicable from version `1.0.0` onwards.
 
 ## [Unreleased]
 
+### Added
+
+- APPCLI-133: Add fix for Git repository ownership issue to the AppCli Dockerfile.
+
 ### Fixed
 
 - APED-37: Prevent quoted arguments with spaces splitting into multiple arguments in the launcher script.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,15 @@ RUN \
         vim-tiny \
     && apt-get -y autoremove \
     && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # Git has recently added more strict requirements for directory ownership
+    # of Git managed directories. This has caused issues with updating to new
+    # releases as the '/conf' directory is managed by Git. To address this
+    # ownership issue, we can define directories as safe in the git config
+    # settings. Currently, it does not support defining directories in the
+    # following way: '/opt/brightsparklabs/*'. Instead, we have to define
+    # all directories as safe, which given this is only within the context
+    # of a docker image, is acceptable. In future, when the above means of
+    # defining safe directories is added, we should update this command to
+    #be more explicit around what directories should be considered safe.
+    && git config --global --add safe.directory '*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,5 @@ RUN \
     # all directories as safe, which given this is only within the context
     # of a docker image, is acceptable. In future, when the above means of
     # defining safe directories is added, we should update this command to
-    #be more explicit around what directories should be considered safe.
+    # be more explicit around what directories should be considered safe.
     && git config --global --add safe.directory '*'


### PR DESCRIPTION
Apply a working fix for the git repository ownership issue currently implemented in a number of AppCli applications.
This will apply the fix to the underlying Docker image that those applications are building off, allowing it to cover all newly built instances, rather than just the ones where the fix has been explicitly applied. 
A comment explaining reason for adding the fix and future changes once functionality is implemented is included.